### PR TITLE
add multilevel testing from qcengine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       run: |
         pytest -rws -v ${{ matrix.cfg.pytest }} --color=yes \
             --cov=qcmanybody --cov-report=xml \
-            --durations 50 --durations-min 5 .
+            --durations 50 --durations-min 5
 
     - name: CodeCov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
 
     - name: PyTest
       run: |
-        pytest -rws -v ${{ matrix.cfg.pytest }} --cov=qcmanybody --color=yes --cov-report=xml --durations 50 --durations-min 5 qcmanybody/ tests/
+        pytest -rws -v ${{ matrix.cfg.pytest }} --color=yes \
+            --cov=qcmanybody --cov-report=xml \
+            --durations 50 --durations-min 5 .
 
     - name: CodeCov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,15 @@ jobs:
             - pytest-cov
             - codecov
             # Testing CMS
-            - nwchem
-            - networkx
+            - psi4
+            #- nwchem  # lands on different he4 soln
+            #- networkx
           EOF
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             :
             if [[ "${{ matrix.cfg.label }}" == "Py-min" ]]; then
                 sed -i "s;pydantic;pydantic=1;g" export.yaml
+                sed -i "s;- psi4;#- psi4;g" export.yaml
                 sed -i "s;- nwchem;#- nwchem;g" export.yaml
                 sed -i "s;- networkx;#- networkx;g" export.yaml
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           - label: Py-max
             python-version: "3.12"
             runs-on: ubuntu-latest
-            pytest: "-k 'not (he4 and all)'"
+            pytest: "-k 'not (he4 and 4b)'"
 
     name: "🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.label }} • ${{ matrix.cfg.runs-on }}"
     runs-on: ${{ matrix.cfg.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
           - label: Py-min
             python-version: "3.8"
             runs-on: ubuntu-latest
-            pytest: ""
+            pytest: "-m 'not addon'"
 
           - label: Py-max
             python-version: "3.12"
             runs-on: ubuntu-latest
-            pytest: "-k 'not (he4 and 4b)'"
+            pytest: "-k 'not (he4 and (3b or 4b))'"
 
     name: "🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.label }} • ${{ matrix.cfg.runs-on }}"
     runs-on: ${{ matrix.cfg.runs-on }}
@@ -66,9 +66,6 @@ jobs:
             :
             if [[ "${{ matrix.cfg.label }}" == "Py-min" ]]; then
                 sed -i "s;pydantic;pydantic=1;g" export.yaml
-                sed -i "s;- psi4;#- psi4;g" export.yaml
-                sed -i "s;- nwchem;#- nwchem;g" export.yaml
-                sed -i "s;- networkx;#- networkx;g" export.yaml
             fi
           fi
           # model sed for L/W
@@ -111,9 +108,9 @@ jobs:
 
     - name: PyTest
       run: |
-        pytest -rws -v ${{ matrix.cfg.pytest }} --color=yes \
+        pytest -rws -v ${{ matrix.cfg.pytest }} \
             --cov=qcmanybody --cov-report=xml \
-            --durations 50 --durations-min 5
+            --color=yes --durations 50 --durations-min 20
 
     - name: CodeCov
       uses: codecov/codecov-action@v3

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,10 +2,12 @@
 minversion = 7.0
 addopts = --import-mode=importlib
 
+# locations from which test helper fls can be imported
 pythonpath =
     tests/
     qcmanybody/models
 
+# test fl locations rel to this fl to use if paths not specified
 testpaths =
     tests/
     qcmanybody/models

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ minversion = 7.0
 addopts = --import-mode=importlib
 
 testpaths =
-    tests
+    tests/
     qcmanybody/models
 
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,10 @@
 minversion = 7.0
 addopts = --import-mode=importlib
 
+pythonpath =
+    tests/
+    qcmanybody/models
+
 testpaths =
     tests/
     qcmanybody/models

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,16 @@
+[pytest]
+minversion = 7.0
+addopts = --import-mode=importlib
+
+testpaths =
+    tests
+    qcmanybody/models
+
+markers =
+    addon: "tests require external non-required software"
+
+    cfour: "tests using CFOUR software; skip if unavailable"
+    gamess: "tests using GAMESS software; skip if unavailable"
+    nwchem: "tests using classic NWChem software; skip if unavailable"
+    psi4: "tests using Psi4 software; skip if unavailable"
+

--- a/qcmanybody/builder.py
+++ b/qcmanybody/builder.py
@@ -81,7 +81,7 @@ def build_nbody_compute_list(
 
     # Build up compute sets
     if "cp" in bsse_type:
-        # Everything is in full n-mer basis
+        # Everything is in counterpoise/nfr-mer basis
         basis_tuple = tuple(fragment_range)
 
         if supersystem_ie_only:
@@ -90,13 +90,18 @@ def build_nbody_compute_list(
                     cp_compute_list[nfragments].add((x, basis_tuple))
         else:
             for nb in nbodies:
+                # Note A.1: nb=1 is skipped because the nfr-mer-basis monomer
+                #   contributions cancel at 1-body. These skipped tasks will be
+                #   ordered anyways if higher bodies are requested. Monomers for
+                #   the purpose of total energies use monomer basis, not these
+                #   skipped tasks. See coordinating Note A.2 .
                 if nb > 1:
                     for sublevel in range(1, nb + 1):
                         for x in itertools.combinations(fragment_range, sublevel):
                             cp_compute_list[nb].add((x, basis_tuple))
 
     if "nocp" in bsse_type:
-        # Everything in monomer basis
+        # Everything in natural/n-mer basis
         if supersystem_ie_only:
             for sublevel in [1, nfragments]:
                 for x in itertools.combinations(fragment_range, sublevel):
@@ -121,8 +126,8 @@ def build_nbody_compute_list(
     if return_total_data and 1 in nbodies:
         # Monomers in monomer basis
         nocp_compute_list.setdefault(1, set())
-        for frag in range(1, nfragments + 1):
-            nocp_compute_list[1].add(((frag,), (frag,)))
+        for ifr in fragment_range:
+            nocp_compute_list[1].add(((ifr,), (ifr,)))
 
     if include_supersystem:
         # Add supersystem info to the compute list (nocp only)

--- a/qcmanybody/manybody.py
+++ b/qcmanybody/manybody.py
@@ -170,8 +170,8 @@ class ManyBodyCalculator:
         """
 
         # which level are we assembling?
-        delabled = [delabeler(k) for k in component_results.keys()]
-        mc_level_labels = {x[0] for x in delabled}
+        delabeled = [delabeler(k) for k in component_results.keys()]
+        mc_level_labels = {x[0] for x in delabeled}
 
         if len(mc_level_labels) != 1:
             raise RuntimeError(f"Multiple model chemistries passed into _assemble_nbody_components: {mc_level_labels}")
@@ -326,7 +326,14 @@ class ManyBodyCalculator:
             filtered_results = {k: v for k, v in property_results.items() if delabeler(k)[0] == mc_label}
 
             if not filtered_results:
-                raise RuntimeError(f"No data found for model chemistry {mc_label}")
+                if nbody_list == [1]:
+                    # Note A.2: Note A.1 holds, but for the special case of CP-only
+                    #   and rtd=False and multilevel with a separate level for
+                    #   1-body, the skipped tasks run afoul of sanity checks, so
+                    #   we'll add a dummy result.
+                    filtered_results = {labeler(mc_label, [1000], [1000]): shaped_zero(property_shape)}
+                else:
+                    raise RuntimeError(f"No data found for model chemistry {mc_label}")
 
             nb_component_results = self._assemble_nbody_components(property_label, filtered_results)
             mc_results[mc_label] = nb_component_results

--- a/qcmanybody/models/addons.py
+++ b/qcmanybody/models/addons.py
@@ -1,0 +1,78 @@
+from typing import List
+
+import pytest
+
+from qcelemental.util import parse_version, which, which_import
+from qcengine.testing import _programs as _programs_qcng
+
+
+__all__ = [
+    "using",
+    "uusing",
+]
+
+
+def is_qcfractal_new_enough(version_feature_introduced):
+    if not which_import('qcfractal', return_bool=True):
+        return False
+    import qcfractal
+    return parse_version(qcfractal.__version__) >= parse_version(version_feature_introduced)
+
+
+# Figure out what is imported
+# * anything _not_ in QCEngine goes here
+_programs = {
+    "vasp": False,
+}
+
+
+def has_program(name):
+    # any aliases or merged names go here
+    if name in _programs:
+        return _programs[name]
+    elif name in _programs_qcng:
+        return _programs_qcng[name]
+    else:
+        raise KeyError(f"Program {name} not registered with QCManyBody testing.")
+
+
+_using_cache = {}
+
+
+def _using(program: str) -> None:
+    if program not in _using_cache:
+        import_message = f"Not detecting module {program}. Install package if necessary to enable tests."
+        skip = pytest.mark.skipif(has_program(program) is False, reason=import_message)
+        general = pytest.mark.addon
+        particular = getattr(pytest.mark, program)
+
+        all_marks = (skip, general, particular)
+        _using_cache[program] = [_compose_decos(all_marks), all_marks]
+
+
+def _compose_decos(decos):
+    # thanks, https://stackoverflow.com/a/45517876
+    def composition(func):
+        for deco in reversed(decos):
+            func = deco(func)
+        return func
+    return composition
+
+
+def uusing(program: str):
+    """Apply 3 marks: skipif program not detected, label "addon", and label program.
+    This is the decorator form for whole test functions: `@mark\n@mark`.
+
+    """
+    _using(program)
+    return _using_cache[program][0]
+
+
+def using(program: str) -> List:
+    """Apply 3 marks: skipif program not detected, label "addon", and label program.
+    This is the inline form for parameterizations: `marks=[]`.
+    In combo, do `marks=[*using(), pytest.mark.quick]`
+
+    """
+    _using(program)
+    return _using_cache[program][1]

--- a/qcmanybody/models/qcng_computer.py
+++ b/qcmanybody/models/qcng_computer.py
@@ -379,6 +379,11 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
         )
         nb_per_mc = computer_model.nbodies_per_mc_level
 
+        print("\n<<<  (ZZ 1) QCEngine harness ManyBodyComputerQCNG.from_qcschema_ben  >>>")
+        # v2: pprint.pprint(computer_model.model_dump(), width=200)
+        pprint.pprint(computer_model.dict(), width=200)
+        print(f"nbodies_per_mc_level={nb_per_mc}")
+
         comp_levels = {}
         for mc_level_idx, mtd in enumerate(computer_model.levels.values()):
             for lvl1 in nb_per_mc[mc_level_idx]:
@@ -401,6 +406,9 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
             computer_model.supersystem_ie_only,
         )
 
+        print("\n<<<  (ZZ 2) QCManyBody module ManyBodyCalculator  >>>")
+        print(dir(calculator_cls))
+
         component_results = {}
 
         for chem, label, imol in calculator_cls.iterate_molecules():
@@ -421,11 +429,18 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
             for p in props:
                 if hasattr(result.properties, f"return_{p}"):
                     v = getattr(result.properties, f"return_{p}")
+                    # print(f"  {label} {p}: {v}")
                     if v is not None:
                         component_results[label][p] = v
 
+        print("\n<<<  (ZZ 2) QCEngine harness ManyBodyComputerQCNG.from_qcschema_ben component_results  >>>")
+        pprint.pprint(component_results, width=200)
+
+        print("start to analyze")
         analyze_back = calculator_cls.analyze(component_results)
         analyze_back["nbody_number"] = len(component_results)
+        print("\n<<<  (ZZ 3) QCEngine harness ManyBodyComputerQCNG.from_qcschema_ben analyze_back  >>>")
+        pprint.pprint(analyze_back, width=200)
 
         return computer_model.get_results(external_results=analyze_back)
 

--- a/qcmanybody/models/test_mbe_he4_multilevel.py
+++ b/qcmanybody/models/test_mbe_he4_multilevel.py
@@ -1,0 +1,594 @@
+import copy
+import pprint
+
+import pytest
+
+from qcelemental import constants
+from qcelemental.models import Molecule
+# v2: from qcelemental.models.procedures_manybody import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
+from qcelemental.testing import compare_values
+
+from qcmanybody.models.manybody_v1 import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
+from qcmanybody.models.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
+
+import qcengine as qcng
+from qcengine.testing import using
+
+def skprop(qcvar):
+    # qcng: return qcng.procedures.manybody.qcvars_to_manybodyproperties[qcvar]
+    return qcvars_to_manybodyproperties[qcvar]
+
+
+@pytest.fixture(scope="function")
+def mbe_data_multilevel_631g():
+    # note that spherical/cartesian irrelevant for He & 6-31G, and fc/ae irrelevant for He
+    c4_kwds = {}
+    gms_kwds = {"basis__ngauss": 6, "ccinp__ncore": 0, "ccinp__iconv": 9, "scf__conv": 9}
+    nwc_kwds = {"scf__thresh": 1.0e-8, "ccsd__thresh": 1.e-8}
+    p4_kwds = {"scf_type": "pk", "mp2_type": "conv"}
+
+    protocols = {"stdout": False}
+    return {
+        "specification": {
+            "specification": {
+                "c4-hf": {
+                    "model": {
+                        "method": "hf",
+                        "basis": "6-31g",
+                    },
+                    "driver": "energy",
+                    "program": "cfour",
+                    "keywords": c4_kwds,
+                    "protocols": protocols,
+                },
+                "c4-mp2": {
+                    "model": {
+                        "method": "mp2",
+                        "basis": "6-31g",
+                    },
+                    "driver": "energy",
+                    "program": "cfour",
+                    "keywords": c4_kwds,
+                    "protocols": protocols,
+                },
+                "c4-ccsd": {
+                    "model": {
+                        "method": "ccsd",
+                        "basis": "6-31g",
+                    },
+                    "driver": "energy",
+                    "program": "cfour",
+                    "keywords": c4_kwds,
+                    "protocols": protocols,
+                },
+                "gms-hf": {
+                    "model": {
+                        "method": "hf",
+                        "basis": "n31",
+                    },
+                    "driver": "energy",
+                    "program": "gamess",
+                    "keywords": gms_kwds,
+                    "protocols": protocols,
+                },
+                "gms-mp2": {
+                    "model": {
+                        "method": "mp2",
+                        "basis": "n31",
+                    },
+                    "driver": "energy",
+                    "program": "gamess",
+                    "keywords": gms_kwds,
+                    "protocols": protocols,
+                },
+                "gms-ccsd": {
+                    "model": {
+                        "method": "ccsd",
+                        "basis": "n31",
+                    },
+                    "driver": "energy",
+                    "program": "gamess",
+                    "keywords": gms_kwds,
+                    "protocols": protocols,
+                },
+                "nwc-hf": {
+                    "model": {
+                        "method": "hf",
+                        "basis": "6-31g",
+                    },
+                    "driver": "energy",
+                    "program": "nwchem",
+                    "keywords": nwc_kwds,
+                    "protocols": protocols,
+                },
+                "nwc-mp2": {
+                    "model": {
+                        "method": "mp2",
+                        "basis": "6-31g",
+                    },
+                    "driver": "energy",
+                    "program": "nwchem",
+                    "keywords": nwc_kwds,
+                    "protocols": protocols,
+                },
+                "nwc-ccsd": {
+                    "model": {
+                        "method": "ccsd",
+                        "basis": "6-31g",
+                    },
+                    "driver": "energy",
+                    "program": "nwchem",
+                    "keywords": nwc_kwds,
+                    "protocols": protocols,
+                },
+                "p4-hf": {
+                    "model": {
+                        "method": "hf",
+                        "basis": "6-31g",
+                    },
+                    "driver": "energy",
+                    "program": "psi4",
+                    "keywords": p4_kwds,
+                    "protocols": protocols,
+                },
+                "p4-mp2": {
+                    "model": {
+                        "method": "mp2",
+                        "basis": "6-31g",
+                    },
+                    "driver": "energy",
+                    "program": "psi4",
+                    "keywords": p4_kwds,
+                    "protocols": protocols,
+                },
+                "p4-ccsd": {
+                    "model": {
+                        "method": "ccsd",
+                        "basis": "6-31g",
+                    },
+                    "driver": "energy",
+                    "program": "psi4",
+                    "keywords": p4_kwds,
+                    "protocols": protocols,
+                },
+            },
+            "keywords": None,
+            "driver": "energy",
+        },
+        "molecule": None,
+    }
+
+
+he4_refs_conv_multilevel_631g = {
+    # 1: ccsd; 2,3: mp2; 4: hf, all 6-31G
+    "121": {
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY":       -11.480648555603,
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY":       -11.472000052247,
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY":       -11.472089645469,
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY":       -11.472068853166,
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY":   0.008648503357,
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY":   0.008558910134,
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY":   0.008579702437,
+        "NOCP-CORRECTED 2-BODY CONTRIBUTION TO ENERGY":       0.008648503357,
+        "NOCP-CORRECTED 3-BODY CONTRIBUTION TO ENERGY":      -0.000089593222,
+        "NOCP-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":       0.000020792303,
+
+        "CP-CORRECTED TOTAL ENERGY THROUGH 1-BODY":         -11.480648555603,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 2-BODY":         -11.471058574581,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 3-BODY":         -11.471324608815,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY":         -11.471272244751,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY":   0.009589981022,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY":   0.009323946788,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY":   0.009376310852,
+        "CP-CORRECTED 2-BODY CONTRIBUTION TO ENERGY":       0.009589981022,
+        "CP-CORRECTED 3-BODY CONTRIBUTION TO ENERGY":       -0.000266034234,
+        "CP-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":       0.000052364064,
+    },
+    # 1,2: ccsd; 3,4: mp2, all 6-31G
+    "22": {
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY":    -11.480648555603,
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY":    -11.471764016410,
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY":    -11.471853609632,
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY":    -11.471834096023,
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY":    0.008884539193,
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY":    0.008794945971,
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY":    0.008814459580,
+        "NOCP-CORRECTED 2-BODY CONTRIBUTION TO ENERGY":    0.008884539193,
+        "NOCP-CORRECTED 3-BODY CONTRIBUTION TO ENERGY":    -0.000089593222,
+        "NOCP-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":    0.000019513609,
+
+        "CP-CORRECTED TOTAL ENERGY THROUGH 1-BODY":      -11.480648555603,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 2-BODY":      -11.470705938773,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 3-BODY":      -11.470971973006,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY":      -11.470913449084,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY":      0.009942616831,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY":      0.009676582597,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY":      0.009735106519,
+        "CP-CORRECTED 2-BODY CONTRIBUTION TO ENERGY":      0.009942616831,
+        "CP-CORRECTED 3-BODY CONTRIBUTION TO ENERGY":      -0.000266034234,
+        "CP-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":      0.000058523922,
+    },
+}
+
+# only here for keys
+he4_refs_conv = {
+        "CP-CORRECTED TOTAL ENERGY THROUGH 1-BODY":           -11.530668717083888,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 2-BODY":           -11.522467757090013,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 3-BODY":           -11.522702864080149,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY":           -11.522639870651439,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY":       0.008200959993875045,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY":       0.007965853003739198,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY":       0.008028846432448944,
+        "CP-CORRECTED 2-BODY CONTRIBUTION TO ENERGY":           0.008200959993875045,
+        "CP-CORRECTED 3-BODY CONTRIBUTION TO ENERGY":          -0.00023510699013584713,
+        "CP-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":           6.299342870974556e-05,
+
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY":         -11.530668717083888,
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY":         -11.522851206178828,
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY":         -11.523095269671348,
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY":         -11.523038093664368,
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY":     0.007817510905059777,
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY":     0.0075734474125397355,
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY":     0.007630623419519367,
+        "NOCP-CORRECTED 2-BODY CONTRIBUTION TO ENERGY":         0.007817510905059777,
+        "NOCP-CORRECTED 3-BODY CONTRIBUTION TO ENERGY":        -0.00024406349252004134,
+        "NOCP-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":         5.717600697963121e-05,
+
+        "VMFC-CORRECTED TOTAL ENERGY THROUGH 1-BODY":         -11.530668717083888,
+        "VMFC-CORRECTED TOTAL ENERGY THROUGH 2-BODY":         -11.52244892169719,
+        "VMFC-CORRECTED TOTAL ENERGY THROUGH 3-BODY":         -11.52268452228489,
+        "VMFC-CORRECTED TOTAL ENERGY THROUGH 4-BODY":         -11.522621528856181,
+        "VMFC-CORRECTED INTERACTION ENERGY THROUGH 2-BODY":     0.00821979538669737,
+        "VMFC-CORRECTED INTERACTION ENERGY THROUGH 3-BODY":     0.007984194798996924,
+        "VMFC-CORRECTED INTERACTION ENERGY THROUGH 4-BODY":     0.00804718822770667,
+        "VMFC-CORRECTED 2-BODY CONTRIBUTION TO ENERGY":         0.00821979538669737,
+        "VMFC-CORRECTED 3-BODY CONTRIBUTION TO ENERGY":        -0.00023560058770044634,
+        "VMFC-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":         6.299342870974556e-05,
+}
+
+sumdict = {
+    "4b_all": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+        "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+        "VMFC-CORRECTED TOTAL ENERGY": "VMFC-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "VMFC-CORRECTED INTERACTION ENERGY": "VMFC-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "4b_nocpcp": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+        "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "4b_nocp_rtd_sio": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "4b_nocp_sio": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "4b_cp_rtd_sio": {
+        "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "4b_cp_sio": {
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "4b_nocp_rtd": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "4b_nocp": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "4b_cp_rtd": {
+        "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "4b_cp": {
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+    },
+    "3b_nocp_rtd": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
+    },
+    "3b_nocp": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
+    },
+    "3b_cp_rtd": {
+        "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
+    },
+    "3b_cp": {
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
+    },
+    "2b_nocp_rtd": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
+    },
+    "2b_nocp": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
+    },
+    "2b_cp_rtd": {
+        "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
+    },
+    "2b_cp": {
+        "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
+    },
+    "1b_nocp_rtd": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "zero",  #"NOCP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
+    },
+    "1b_nocp": {
+        "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
+        "NOCP-CORRECTED INTERACTION ENERGY": "zero",  #"NOCP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
+    },
+    "1b_cp_rtd": {
+        "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
+        "CP-CORRECTED INTERACTION ENERGY": "zero",  #"CP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
+    },
+    "1b_cp": {
+        "CP-CORRECTED INTERACTION ENERGY": "zero",  #"CP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
+    },
+# TODO table defines the general qcvar as 0 even if 1-body qcvar not available. continue?
+}
+
+
+@pytest.fixture
+def he_tetramer():
+    a2 = 2 / constants.bohr2angstroms
+    return Molecule(symbols=["He", "He", "He", "He"], fragments=[[0], [1], [2], [3]], geometry=[0, 0, 0, 0, 0, a2, 0, a2, 0, 0, a2, a2])
+
+
+@pytest.mark.parametrize("levels", [
+    # pattern 121
+    pytest.param({4: "c4-hf", 3: "c4-mp2", 1: "c4-ccsd"}, id="121-cfour_pure", marks=using("cfour")),
+    ##pytest.param({4: "gms-hf", 3: "gms-mp2", 1: "gms-ccsd"}, id="121-gamess_pure", marks=using("gamess")),
+    pytest.param({4: "nwc-hf", 3: "nwc-mp2", 1: "nwc-ccsd"}, id="121-nwchem_pure", marks=using("nwchem")),
+    pytest.param({4: "p4-hf", 3: "p4-mp2", 1: "p4-ccsd"}, id="121-psi4_pure", marks=using("psi4")),
+
+    pytest.param({4: "p4-hf", 3: "c4-mp2", 1: "c4-ccsd"}, id="121-cfour_psi4", marks=[using("cfour"), using("psi4")]),
+    pytest.param({4: "nwc-hf", 3: "nwc-mp2", 1: "p4-ccsd"}, id="121-nwchem_psi4", marks=[using("nwchem"), using("psi4")]),
+    pytest.param({4: "c4-hf", 3: "nwc-mp2", 1: "p4-ccsd"}, id="121-cfour_nwchem_psi4", marks=[using("cfour"), using("nwchem"), using("psi4")]),
+
+    # pattern 22
+    pytest.param({4: "c4-mp2", 2: "c4-ccsd"}, id="22-cfour_pure", marks=using("cfour")),
+    ##pytest.param({4: "gms-mp2", 2: "gms-ccsd"}, id="22-gamess_pure", marks=using("gamess")),
+    pytest.param({4: "nwc-mp2", 2: "nwc-ccsd"}, id="22-nwchem_pure", marks=using("nwchem")),
+    pytest.param({4: "p4-mp2", 2: "p4-ccsd"}, id="22-psi4_pure", marks=using("psi4")),
+])
+@pytest.mark.parametrize("mbe_keywords,anskey,bodykeys,calcinfo_nmbe", [
+#    pytest.param(
+#        {"bsse_type": ["nocp", "cp", "vmfc"]},
+#        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+#        [k for k in he4_refs_conv],
+#        {"121": 65,
+#         "22": 99},  #
+#        id="4b_all"),
+    pytest.param(  # ODD entry b/c no vmfc ready for multilevel
+        {"bsse_type": ["nocp", "cp"]},
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+        [k for k in he4_refs_conv if not k.startswith("VMFC-")],
+        {"121": 61,  # cp(14md + 15lo) + nocp(14md + 15lo) + 4hi - 1lo 1234@1234
+         "22": 49},  # cp(10hi + 15lo) + nocp(10hi + 15lo) - 1lo 1234@1234
+        id="4b_nocpcp"),
+#    pytest.param(
+#        {"bsse_type": "nocp", "return_total_data": True, "supersystem_ie_only": True},
+#        "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+#        [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("THROUGH 4-BODY" in k or "THROUGH 1-BODY" in k))],
+#        {"121": 5,
+#         "22": 99},  #
+#        id="4b_nocp_rtd_sio"),
+#    pytest.param(
+#        {"bsse_type": "nocp", "return_total_data": False, "supersystem_ie_only": True},
+#        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+#        [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("THROUGH 4-BODY" in k or "THROUGH 1-BODY" in k))],
+#        {"121": 5,
+#         "22": 99},  #
+#        id="4b_nocp_sio"),
+#    pytest.param(
+#        {"bsse_type": "cp", "return_total_data": True, "supersystem_ie_only": True},
+#        "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+#        [k for k in he4_refs_conv if (k.startswith("CP-") and ("THROUGH 4-BODY" in k or "THROUGH 1-BODY" in k))],
+#        {"121": 9,
+#         "22": 99},  #
+#        id="4b_cp_rtd_sio"),
+#    pytest.param(
+#        {"bsse_type": "cp", "return_total_data": False, "supersystem_ie_only": True},
+#        "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+#        [k for k in he4_refs_conv if (k.startswith("CP-") and ("THROUGH 4-BODY" in k or "THROUGH 1-BODY" in k) and "TOTAL ENERGY" not in k)],
+#        {"121": 5,
+#         "22": 99},  #
+#        id="4b_cp_sio"),
+### TODO add vmfc. 3b nmbe=50
+    pytest.param(
+        {"bsse_type": "nocp", "return_total_data": True},
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        [k for k in he4_refs_conv if (k.startswith("NOCP-"))],
+        {"121": 33,  # 4hi + 14md + 15lo vs. 15 for single-level
+         "22": 25},  # 10hi + 15lo
+        id="4b_nocp_rtd"),
+    pytest.param(
+        {"bsse_type": "nocp", "return_total_data": False},
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+        [k for k in he4_refs_conv if (k.startswith("NOCP-"))],
+        {"121": 33,  # could be 29 TODO,  # 14md + 15lo vs. 15 for single-level
+         "22": 25},  # 10hi + 15lo
+        id="4b_nocp"),
+    pytest.param(
+        {"bsse_type": "cp", "return_total_data": True},
+        "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        [k for k in he4_refs_conv if (k.startswith("CP-"))],
+        {"121": 33,  # 4hi(nocp) + 14md + 15lo vs. 19 for single-level,
+         "22": 29},  # 10hi + 15lo + 4hi(nocp)
+        id="4b_cp_rtd"),
+    pytest.param(
+        {"bsse_type": "cp", "return_total_data": False},
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
+        [k for k in he4_refs_conv if (k.startswith("CP-") and "TOTAL ENERGY" not in k)],
+        {"121": 29, # 14md + 15lo vs. 15 for single-level,
+         "22": 25},  # 10hi + 15lo
+        id="4b_cp"),
+    pytest.param(
+        {"bsse_type": "nocp", "return_total_data": True, "max_nbody": 3},
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
+        [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("4-BODY" not in k))],
+        {"121": 18,  # 4hi + 14md vs. 14 for single-level
+         "22": 24},  # 10hi + 14lo
+        id="3b_nocp_rtd"),
+    pytest.param(
+        {"bsse_type": "nocp", "return_total_data": False, "max_nbody": 3},
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
+        [k for k in he4_refs_conv if (k.startswith("NOCP-") and "4-BODY" not in k)],
+        {"121": 18,  # 4hi + 14md vs. 14 for single-level
+         "22": 24},  # 10hi + 14lo
+        id="3b_nocp"),
+    pytest.param(
+        {"bsse_type": "cp", "return_total_data": True, "max_nbody": 3},
+        "CP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
+        [k for k in he4_refs_conv if (k.startswith("CP-") and "4-BODY" not in k)],
+        {"121": 18,  # 4hi + 14md vs. 18 for single-level  # bugfix: was 28
+         "22": 28},  # 10hi + 14lo + 4hi(nocp)
+        id="3b_cp_rtd"),
+    pytest.param(
+        {"bsse_type": "cp", "return_total_data": False, "max_nbody": 3},
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
+        [k for k in he4_refs_conv if (k.startswith("CP-") and "4-BODY" not in k and "TOTAL ENERGY" not in k)],
+        {"121": 14,  # 14md vs. 14 for single-level
+         "22": 24},  # 10hi + 14lo
+        id="3b_cp"),
+    pytest.param(
+        {"bsse_type": "nocp", "return_total_data": True, "max_nbody": 2},
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
+        [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
+        {"121": 14,  # 4hi + 10md vs. 10 for single-level
+         "22": 10},  # 10hi
+        id="2b_nocp_rtd"),
+    pytest.param(
+        {"bsse_type": "nocp", "return_total_data": False, "max_nbody": 2},
+        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
+        [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
+        {"121": 14,  # 4hi + 10md vs. 10 for single-level,
+         "22": 10},  # 10hi
+        id="2b_nocp"),
+    pytest.param(
+        {"bsse_type": "cp", "return_total_data": True, "max_nbody": 2},
+        "CP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
+        [k for k in he4_refs_conv if (k.startswith("CP-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
+        {"121": 14,  # 4hi + 10md vs. 14 for single-level,
+         "22": 14},  # 10hi + 4hi(nocp)
+        id="2b_cp_rtd"),
+    pytest.param(
+        {"bsse_type": "cp", "return_total_data": False, "max_nbody": 2},
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
+        [k for k in he4_refs_conv if (k.startswith("CP-") and ("4-BODY" not in k) and ("3-BODY" not in k) and "TOTAL ENERGY" not in k)],
+        {"121": 10,  # 10md vs. 10 for single-level,
+         "22": 10},  # 10hi
+        id="2b_cp"),
+    pytest.param(
+        {"bsse_type": "nocp", "return_total_data": True, "max_nbody": 1},
+        "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
+        [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("1-BODY" in k))],
+        {"121": 4,  # 4hi
+         "22": 4},
+        id="1b_nocp_rtd"),
+## TODO fix 1b for rtd=F
+##    pytest.param(
+##        {"bsse_type": "nocp", "return_total_data": False, "max_nbody": 1},
+##        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
+##        [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("1-BODY" in k))],
+##        {"121": 10,
+##         "22": 99},  #
+##        id="1b_nocp"),
+    pytest.param(
+        {"bsse_type": "cp", "return_total_data": True, "max_nbody": 1},
+        "CP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
+        [k for k in he4_refs_conv if (k.startswith("CP-") and ("1-BODY" in k))],
+        {"121": 4,  # 4hi
+         "22": 4},
+        id="1b_cp_rtd"),
+##    pytest.param(
+##        {"bsse_type": "cp", "return_total_data": False, "max_nbody": 1},
+##        "CP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
+##        [k for k in he4_refs_conv if (k.startswith("CP-") and ("1-BODY" in k) and "TOTAL ENERGY" not in k)],
+##        {"121": 4,
+##         "22": 99},  #
+##        id="1b_cp"),
+])
+def test_nbody_he4_multi(levels, mbe_keywords, anskey, bodykeys, calcinfo_nmbe, he_tetramer, request, mbe_data_multilevel_631g):
+    _inner = request.node.name.split("[")[1].split("]")[0]
+    kwdsln, pattern, progln = _inner.split("-")
+
+    levels = copy.deepcopy(levels)
+    if pattern == "121":
+        if mbe_keywords.get("max_nbody", 4) == 3:
+            del levels[4]  # max_nbody and levels silently contradict w/o this
+        elif mbe_keywords.get("max_nbody", 4) == 2:
+            levels = {2: levels[3], 1: levels[1]}
+        elif mbe_keywords.get("max_nbody", 4) == 1:
+            del levels[4]
+            del levels[3]
+    elif pattern == "22":
+        if mbe_keywords.get("max_nbody", 4) == 3:
+            levels = {3: levels[4], 2: levels[2]}
+        if mbe_keywords.get("max_nbody", 4) == 2:
+            del levels[4]
+        if mbe_keywords.get("max_nbody", 4) == 1:
+            levels = {1: levels[2]}
+
+    mbe_keywords = ManyBodyKeywords(levels=levels, **mbe_keywords)
+    mbe_data_multilevel_631g["molecule"] = he_tetramer
+    mbe_data_multilevel_631g["specification"]["keywords"] = mbe_keywords
+    mbe_model = ManyBodyInput(**mbe_data_multilevel_631g)
+
+    if "gamess" in progln:
+        with pytest.raises(ValueError) as exe:
+            # qcng: qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
+            ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
+        assert "GAMESS+QCEngine can't handle ghost atoms yet" in str(exe.value)
+        pytest.xfail("GAMESS can't do ghosts")
+
+    # qcng: ret = qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
+    ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
+    print(f"MMMMMMM {request.node.name}")
+    pprint.pprint(ret.dict(), width=200)
+
+    refs = he4_refs_conv_multilevel_631g[pattern]
+    ans = refs[anskey]
+    ref_nmbe = calcinfo_nmbe[pattern]
+    atol = 2.0e-8
+
+    for qcv, ref in refs.items():
+        skp = skprop(qcv)
+        if qcv in bodykeys:
+            assert compare_values(ref, ret.extras["qcvars"]["nbody"][qcv], atol=atol, label=f"[a] qcvars {qcv}")
+            assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[b] skprop {skp}")
+        else:
+            assert qcv not in ret.extras["qcvars"]["nbody"], f"[z] {qcv=} wrongly present"
+            assert getattr(ret.properties, skp) is None
+
+    for qcv in sumdict["4b_all"]:
+        skp = skprop(qcv)
+        if qcv in sumdict[kwdsln]:
+            refkey = sumdict[kwdsln][qcv]
+            ref = 0.0 if refkey == "zero" else refs[refkey]
+            assert compare_values(ref, ret.extras["qcvars"]["nbody"][qcv], atol=atol, label=f"[c] qcvars {qcv}")
+            assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[d] skprop {skp}")
+        else:
+            assert qcv not in ret.extras["qcvars"]["nbody"], f"[y] {qcv=} wrongly present"
+            assert getattr(ret.properties, skp) is None
+
+    for qcv, ref in {
+        "CURRENT ENERGY": ans,
+    }.items():
+        skp = skprop(qcv)
+        assert compare_values(ref, ret.extras["qcvars"][qcv], atol=atol, label=f"[e] qcvars {qcv}")
+        assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[f] skprop {skp}")
+    assert compare_values(ans, ret.return_result, atol=atol, label=f"[g] ret")
+    assert ret.properties.calcinfo_nmbe == ref_nmbe, f"{ret.properties.calcinfo_nmbe=} != {ref_nmbe}"

--- a/qcmanybody/models/test_mbe_he4_multilevel.py
+++ b/qcmanybody/models/test_mbe_he4_multilevel.py
@@ -12,7 +12,7 @@ from qcmanybody.models.manybody_v1 import AtomicSpecification, ManyBodyKeywords,
 from qcmanybody.models.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
 
 import qcengine as qcng
-from qcengine.testing import using
+from .addons import using
 
 def skprop(qcvar):
     # qcng: return qcng.procedures.manybody.qcvars_to_manybodyproperties[qcvar]
@@ -353,9 +353,9 @@ def he_tetramer():
     pytest.param({4: "nwc-hf", 3: "nwc-mp2", 1: "nwc-ccsd"}, id="121-nwchem_pure", marks=using("nwchem")),
     pytest.param({4: "p4-hf", 3: "p4-mp2", 1: "p4-ccsd"}, id="121-psi4_pure", marks=using("psi4")),
 
-    pytest.param({4: "p4-hf", 3: "c4-mp2", 1: "c4-ccsd"}, id="121-cfour_psi4", marks=[using("cfour"), using("psi4")]),
-    pytest.param({4: "nwc-hf", 3: "nwc-mp2", 1: "p4-ccsd"}, id="121-nwchem_psi4", marks=[using("nwchem"), using("psi4")]),
-    pytest.param({4: "c4-hf", 3: "nwc-mp2", 1: "p4-ccsd"}, id="121-cfour_nwchem_psi4", marks=[using("cfour"), using("nwchem"), using("psi4")]),
+    pytest.param({4: "p4-hf", 3: "c4-mp2", 1: "c4-ccsd"}, id="121-cfour_psi4", marks=[*using("cfour"), *using("psi4")]),
+    pytest.param({4: "nwc-hf", 3: "nwc-mp2", 1: "p4-ccsd"}, id="121-nwchem_psi4", marks=[*using("nwchem"), *using("psi4")]),
+    pytest.param({4: "c4-hf", 3: "nwc-mp2", 1: "p4-ccsd"}, id="121-cfour_nwchem_psi4", marks=[*using("cfour"), *using("nwchem"), *using("psi4")]),
 
     # pattern 22
     pytest.param({4: "c4-mp2", 2: "c4-ccsd"}, id="22-cfour_pure", marks=using("cfour")),

--- a/qcmanybody/models/test_mbe_he4_singlelevel.py
+++ b/qcmanybody/models/test_mbe_he4_singlelevel.py
@@ -11,7 +11,7 @@ from qcmanybody.models.manybody_v1 import AtomicSpecification, ManyBodyKeywords,
 from qcmanybody.models.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
 
 import qcengine as qcng
-from qcengine.testing import using
+from .addons import using
 
 def skprop(qcvar):
     # qcng: return qcng.procedures.manybody.qcvars_to_manybodyproperties[qcvar]

--- a/qcmanybody/models/test_mbe_he4_singlelevel.py
+++ b/qcmanybody/models/test_mbe_he4_singlelevel.py
@@ -89,7 +89,7 @@ he4_refs_df = {
     }
 
 sumdict = {
-    "4b-all": {
+    "4b_all": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
@@ -97,79 +97,79 @@ sumdict = {
         "VMFC-CORRECTED TOTAL ENERGY": "VMFC-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         "VMFC-CORRECTED INTERACTION ENERGY": "VMFC-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
     },
-    "4b-nocp-rtd-sio": {
+    "4b_nocp_rtd_sio": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
     },
-    "4b-nocp-sio": {
+    "4b_nocp_sio": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
     },
-    "4b-cp-rtd-sio": {
+    "4b_cp_rtd_sio": {
         "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
     },
-    "4b-cp-sio": {
+    "4b_cp_sio": {
         "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
     },
-    "4b-nocp-rtd": {
+    "4b_nocp_rtd": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
     },
-    "4b-nocp": {
+    "4b_nocp": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
     },
-    "4b-cp-rtd": {
+    "4b_cp_rtd": {
         "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
     },
-    "4b-cp": {
+    "4b_cp": {
         "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
     },
-    "3b-nocp-rtd": {
+    "3b_nocp_rtd": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
     },
-    "3b-nocp": {
+    "3b_nocp": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
     },
-    "3b-cp-rtd": {
+    "3b_cp_rtd": {
         "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
         "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
     },
-    "3b-cp": {
+    "3b_cp": {
         "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
     },
-    "2b-nocp-rtd": {
+    "2b_nocp_rtd": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
     },
-    "2b-nocp": {
+    "2b_nocp": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
     },
-    "2b-cp-rtd": {
+    "2b_cp_rtd": {
         "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
         "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
     },
-    "2b-cp": {
+    "2b_cp": {
         "CP-CORRECTED INTERACTION ENERGY": "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
     },
-    "1b-nocp-rtd": {
+    "1b_nocp_rtd": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "zero",  #"NOCP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
     },
-    "1b-nocp": {
+    "1b_nocp": {
         "NOCP-CORRECTED TOTAL ENERGY": "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
         "NOCP-CORRECTED INTERACTION ENERGY": "zero",  #"NOCP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
     },
-    "1b-cp-rtd": {
+    "1b_cp_rtd": {
         "CP-CORRECTED TOTAL ENERGY": "CP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
         "CP-CORRECTED INTERACTION ENERGY": "zero",  #"CP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
     },
-    "1b-cp": {
+    "1b_cp": {
         "CP-CORRECTED INTERACTION ENERGY": "zero",  #"CP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
     },
 # TODO table defines the general qcvar as 0 even if 1-body qcvar not available. continue?
@@ -183,11 +183,11 @@ def he_tetramer():
 
 
 @pytest.mark.parametrize("program,basis,keywords", [
-    pytest.param("cfour", "aug-pvdz", {"frozen_core": False}, id="cfour-conv", marks=using("cfour")),
-    pytest.param("gamess", "accd", {"contrl__ispher": 1, "mp2__nacore": 0}, id="gamess-conv", marks=using("gamess")),
-    pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "scf__thresh": 1.0e-8, "mp2__freeze": False}, id="nwchem-conv", marks=using("nwchem")),
-    pytest.param("psi4", "aug-cc-pvdz", {"e_convergence": 1.e-10, "d_convergence": 1.e-10, "scf_type": "pk", "mp2_type": "conv"}, id="psi4-conv", marks=using("psi4")),
-    pytest.param("psi4", "aug-cc-pvdz", {"e_convergence": 1.e-10, "d_convergence": 1.e-10}, id="psi4-df", marks=using("psi4")),
+    pytest.param("cfour", "aug-pvdz", {"frozen_core": False}, id="cfour_conv", marks=using("cfour")),
+    pytest.param("gamess", "accd", {"contrl__ispher": 1, "mp2__nacore": 0}, id="gamess_conv", marks=using("gamess")),
+    pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "scf__thresh": 1.0e-8, "mp2__freeze": False}, id="nwchem_conv", marks=using("nwchem")),
+    pytest.param("psi4", "aug-cc-pvdz", {"e_convergence": 1.e-10, "d_convergence": 1.e-10, "scf_type": "pk", "mp2_type": "conv"}, id="psi4_conv", marks=using("psi4")),
+    pytest.param("psi4", "aug-cc-pvdz", {"e_convergence": 1.e-10, "d_convergence": 1.e-10}, id="psi4_df", marks=using("psi4")),
 ])
 @pytest.mark.parametrize("mbe_keywords,anskey,bodykeys,calcinfo_nmbe", [
     pytest.param(
@@ -195,129 +195,129 @@ def he_tetramer():
         "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv],
         65,
-        id="4b-all"),
+        id="4b_all"),
     pytest.param(
         {"bsse_type": "nocp", "return_total_data": True, "supersystem_ie_only": True},
         "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("THROUGH 4-BODY" in k or "THROUGH 1-BODY" in k))],
         5,
-        id="4b-nocp-rtd-sio"),
+        id="4b_nocp_rtd_sio"),
     pytest.param(
         {"bsse_type": "nocp", "return_total_data": False, "supersystem_ie_only": True},
         "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("THROUGH 4-BODY" in k or "THROUGH 1-BODY" in k))],
         5,
-        id="4b-nocp-sio"),
+        id="4b_nocp_sio"),
     pytest.param(
         {"bsse_type": "cp", "return_total_data": True, "supersystem_ie_only": True},
         "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and ("THROUGH 4-BODY" in k or "THROUGH 1-BODY" in k))],
         9,
-        id="4b-cp-rtd-sio"),
+        id="4b_cp_rtd_sio"),
     pytest.param(
         {"bsse_type": "cp", "return_total_data": False, "supersystem_ie_only": True},
         "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and ("THROUGH 4-BODY" in k or "THROUGH 1-BODY" in k) and "TOTAL ENERGY" not in k)],
         5,
-        id="4b-cp-sio"),
+        id="4b_cp_sio"),
 ## TODO add vmfc. 3b nmbe=50
     pytest.param(
         {"bsse_type": "nocp", "return_total_data": True},
         "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-"))],
         15,
-        id="4b-nocp-rtd"),
+        id="4b_nocp_rtd"),
     pytest.param(
         {"bsse_type": "nocp", "return_total_data": False},
         "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-"))],
         15,
-        id="4b-nocp"),
+        id="4b_nocp"),
     pytest.param(
         {"bsse_type": "cp", "return_total_data": True},
         "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-"))],
         19,
-        id="4b-cp-rtd"),
+        id="4b_cp_rtd"),
     pytest.param(
         {"bsse_type": "cp", "return_total_data": False},
         "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and "TOTAL ENERGY" not in k)],
         15,
-        id="4b-cp"),
+        id="4b_cp"),
     pytest.param(
         {"bsse_type": "nocp", "return_total_data": True, "max_nbody": 3},
         "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("4-BODY" not in k))],
         14,
-        id="3b-nocp-rtd"),
+        id="3b_nocp_rtd"),
     pytest.param(
         {"bsse_type": "nocp", "return_total_data": False, "max_nbody": 3},
         "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and "4-BODY" not in k)],
         14,
-        id="3b-nocp"),
+        id="3b_nocp"),
     pytest.param(
         {"bsse_type": "cp", "return_total_data": True, "max_nbody": 3},
         "CP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and "4-BODY" not in k)],
         18,  # bugfix: was 28
-        id="3b-cp-rtd"),
+        id="3b_cp_rtd"),
     pytest.param(
         {"bsse_type": "cp", "return_total_data": False, "max_nbody": 3},
         "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and "4-BODY" not in k and "TOTAL ENERGY" not in k)],
         14,
-        id="3b-cp"),
+        id="3b_cp"),
     pytest.param(
         {"bsse_type": "nocp", "return_total_data": True, "max_nbody": 2},
         "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
         10,
-        id="2b-nocp-rtd"),
+        id="2b_nocp_rtd"),
     pytest.param(
         {"bsse_type": "nocp", "return_total_data": False, "max_nbody": 2},
         "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
         10,
-        id="2b-nocp"),
+        id="2b_nocp"),
     pytest.param(
         {"bsse_type": "cp", "return_total_data": True, "max_nbody": 2},
         "CP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
         14,
-        id="2b-cp-rtd"),
+        id="2b_cp_rtd"),
     pytest.param(
         {"bsse_type": "cp", "return_total_data": False, "max_nbody": 2},
         "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and ("4-BODY" not in k) and ("3-BODY" not in k) and "TOTAL ENERGY" not in k)],
         10,
-        id="2b-cp"),
+        id="2b_cp"),
     pytest.param(
         {"bsse_type": "nocp", "return_total_data": True, "max_nbody": 1},
         "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("1-BODY" in k))],
         4,
-        id="1b-nocp-rtd"),
+        id="1b_nocp_rtd"),
 # TODO fix 1b for rtd=F
 #    pytest.param(
 #        {"bsse_type": "nocp", "return_total_data": False, "max_nbody": 1},
 #        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
 #        [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("1-BODY" in k))],
 #        10,
-#        id="1b-nocp"),
+#        id="1b_nocp"),
     pytest.param(
         {"bsse_type": "cp", "return_total_data": True, "max_nbody": 1},
         "CP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and ("1-BODY" in k))],
         4,
-        id="1b-cp-rtd"),
+        id="1b_cp_rtd"),
 #    pytest.param(
 #        {"bsse_type": "cp", "return_total_data": False, "max_nbody": 1},
 #        "CP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
 #        [k for k in he4_refs_conv if (k.startswith("CP-") and ("1-BODY" in k) and "TOTAL ENERGY" not in k)],
 #        4,
-#        id="1b-cp"),
+#        id="1b_cp"),
 ])
 def test_nbody_he4_single(program, basis, keywords, mbe_keywords, anskey, bodykeys, calcinfo_nmbe, he_tetramer, request):
     #! MP2/aug-cc-pvDZ many body energies of an arbitrary Helium complex,
@@ -330,7 +330,7 @@ def test_nbody_he4_single(program, basis, keywords, mbe_keywords, anskey, bodyke
     if program == "gamess":
         with pytest.raises(ValueError) as exe:
             # qcng: qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
-            qcng_compute_procedure(mbe_model) #, "manybody", raise_error=True)
+            ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
         assert "GAMESS+QCEngine can't handle ghost atoms yet" in str(exe.value)
         pytest.xfail("GAMESS can't do ghosts")
 
@@ -341,26 +341,27 @@ def test_nbody_he4_single(program, basis, keywords, mbe_keywords, anskey, bodyke
     pprint.pprint(ret.dict(), width=200)
 
     _inner = request.node.name.split("[")[1].split("]")[0]
-    kwdsln, progln = "-".join(_inner.split("-")[:-2]), "-".join(_inner.split("-")[-2:])
-    refs = he4_refs_df if progln == "psi4-df" else he4_refs_conv
+    kwdsln, progln = _inner.split("-")
+    refs = he4_refs_df if progln == "psi4_df" else he4_refs_conv
     ans = refs[anskey]
+    atol = 1.0e-8
 
     for qcv, ref in refs.items():
         skp = skprop(qcv)
         if qcv in bodykeys:
-            assert compare_values(ref, ret.extras["qcvars"]["nbody"][qcv], atol=1.0e-8, label=f"[a] qcvars {qcv}")
-            assert compare_values(ref, getattr(ret.properties, skp), atol=1.0e-8, label=f"[b] skprop {skp}")
+            assert compare_values(ref, ret.extras["qcvars"]["nbody"][qcv], atol=atol, label=f"[a] qcvars {qcv}")
+            assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[b] skprop {skp}")
         else:
             assert qcv not in ret.extras["qcvars"]["nbody"], f"[z] {qcv=} wrongly present"
             assert getattr(ret.properties, skp) is None
 
-    for qcv in sumdict["4b-all"]:
+    for qcv in sumdict["4b_all"]:
         skp = skprop(qcv)
         if qcv in sumdict[kwdsln]:
             refkey = sumdict[kwdsln][qcv]
             ref = 0.0 if refkey == "zero" else refs[refkey]
-            assert compare_values(ref, ret.extras["qcvars"]["nbody"][qcv], atol=1.0e-8, label=f"[c] qcvars {qcv}")
-            assert compare_values(ref, getattr(ret.properties, skp), atol=1.0e-8, label=f"[d] skprop {skp}")
+            assert compare_values(ref, ret.extras["qcvars"]["nbody"][qcv], atol=atol, label=f"[c] qcvars {qcv}")
+            assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[d] skprop {skp}")
         else:
             assert qcv not in ret.extras["qcvars"]["nbody"], f"[y] {qcv=} wrongly present"
             assert getattr(ret.properties, skp) is None
@@ -369,7 +370,7 @@ def test_nbody_he4_single(program, basis, keywords, mbe_keywords, anskey, bodyke
         "CURRENT ENERGY": ans,
     }.items():
         skp = skprop(qcv)
-        assert compare_values(ref, ret.extras["qcvars"][qcv], atol=1.0e-8, label=f"[e] qcvars {qcv}")
-        assert compare_values(ref, getattr(ret.properties, skp), atol=1.0e-8, label=f"[f] skprop {skp}")
-    assert compare_values(ans, ret.return_result, atol=1.0e-8, label=f"[g] ret")
+        assert compare_values(ref, ret.extras["qcvars"][qcv], atol=atol, label=f"[e] qcvars {qcv}")
+        assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[f] skprop {skp}")
+    assert compare_values(ans, ret.return_result, atol=atol, label=f"[g] ret")
     assert ret.properties.calcinfo_nmbe == calcinfo_nmbe, f"{ret.properties.calcinfo_nmbe=} != {calcinfo_nmbe}"

--- a/tests/generate_component_data.py
+++ b/tests/generate_component_data.py
@@ -1,5 +1,5 @@
-from .common import mol_h2o_3, specifications
-from .utils import generate_component_data
+from common import mol_h2o_3, specifications
+from utils import generate_component_data
 
 # Generates test data from component
 # This does not generate reference data, but the outputs of the individual calculations

--- a/tests/generate_component_data.py
+++ b/tests/generate_component_data.py
@@ -1,5 +1,5 @@
-from common import mol_h2o_3, specifications
-from utils import generate_component_data
+from .common import mol_h2o_3, specifications
+from .utils import generate_component_data
 
 # Generates test data from component
 # This does not generate reference data, but the outputs of the individual calculations

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -2,8 +2,8 @@ import pytest
 
 from qcmanybody import ManyBodyCalculator
 from qcmanybody.models import BsseEnum
-from .common import mol_h2o_3
-from .utils import load_ref_data, compare_results, load_component_data
+from common import mol_h2o_3
+from utils import load_ref_data, compare_results, load_component_data
 
 
 @pytest.mark.parametrize(

--- a/tests/test_multi_ss.py
+++ b/tests/test_multi_ss.py
@@ -4,8 +4,8 @@ import pytest
 
 from qcmanybody import ManyBodyCalculator
 from qcmanybody.models import BsseEnum
-from .common import mol_h2o_3
-from .utils import load_ref_data, compare_results, load_component_data
+from common import mol_h2o_3
+from utils import load_ref_data, compare_results, load_component_data
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -2,8 +2,8 @@ import pytest
 
 from qcmanybody import ManyBodyCalculator
 from qcmanybody.models import BsseEnum
-from .common import mol_h2o_3
-from .utils import load_ref_data, compare_results, load_component_data
+from common import mol_h2o_3
+from utils import load_ref_data, compare_results, load_component_data
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
(in decreasing importance)

- [x] fixed bug also present in Psi4 dealing with cp 1-body as explained in `Note A`
- [x] added tests of multilevel runs checking return results, qcvars and properties, and calc counts. no vmfc or sio. this is as far as was working in the psi4 implementation.
- [x] switched to testing with psi4. different versions of nwchem can switch SCF roots, so the c-f one doesn't easily match.
- [x] switched pytest mode to `importlib`. this is mostly used when test names can be non-unique, so it's arguable here. removes making tests a module with `__init__.py` and instead test helper files are sourced from pytest.ini's pythonpath.
- [x] switched from using qcng's `using('cms')` to a setup copied from psi4 (`uusing` as decorator and `using` in parametrize). in addition to the `skipif`, this adds `<cms>` and `addon` markers so all the non-instant tests can be avoided with`-m "not addon"`. I don't quite remember but this may also work better than the qcng form for multiple parametrize markers.
- [x] even up `-` vs `_` handling in test files. latter is easier to parse.