### PR TITLE
supersystem_ie_only and levels w/supersystem printing and variables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "autoDocstring.docstringFormat": "numpy-notypes"
+}

--- a/qcmanybody/builder.py
+++ b/qcmanybody/builder.py
@@ -120,6 +120,7 @@ def build_nbody_compute_list(
         for nb in nbodies:
             for cp_combos in itertools.combinations(fragment_range, nb):
                 basis_tuple = tuple(cp_combos)
+                # TODO vmfc_compute_list and vmfc_level_list are identical, so consolidate
                 for interior_nbody in range(1, nb + 1):
                     for x in itertools.combinations(cp_combos, interior_nbody):
                         combo_tuple = (x, basis_tuple)
@@ -158,15 +159,6 @@ def build_nbody_compute_list(
         for nb, lst in nocp_compute_list.items():
             compute_list.setdefault(nb, set())
             compute_list[nb] |= lst
-
-    # Rearrange compute_list from key nb having values to compute all of that nb
-    #   to key nb including values of that nb. Use for counting.
-    compute_list_count = {x: set() for x in nbodies}
-    for nb in nbodies:
-        for nbset in compute_list.values():
-            for item in nbset:
-                if len(item[0]) == nb:
-                    compute_list_count[nb].add(item)
 
     compute_dict = {
         "all": compute_list,

--- a/qcmanybody/manybody.py
+++ b/qcmanybody/manybody.py
@@ -535,21 +535,23 @@ class ManyBodyCalculator:
                 f"{bt.formal()} ({bt.abbr()})",
                 self.nfragments,
                 is_embedded,
+                self.supersystem_ie_only,
+                self.max_nbody if self.has_supersystem else None,
             )
 
         for property_label in available_properties:
             for bt in self.bsse_type:
-                if not self.has_supersystem:  # skipped levels?
-                    nbody_dict.update(
-                        collect_vars(
-                            bt.upper(),
-                            property_label.upper(),
-                            all_results[f"{property_label}_body_dict"][bt],
-                            self.max_nbody,
-                            is_embedded,
-                            self.supersystem_ie_only,
-                        )
+                nbody_dict.update(
+                    collect_vars(
+                        bt.upper(),
+                        property_label.upper(),
+                        all_results[f"{property_label}_body_dict"][bt],
+                        self.max_nbody,
+                        is_embedded,
+                        self.supersystem_ie_only,
+                        self.has_supersystem,
                     )
+                )
 
         all_results["results"] = nbody_dict
         all_results["component_properties"] = component_properties

--- a/qcmanybody/models/manybody_pydv1.py
+++ b/qcmanybody/models/manybody_pydv1.py
@@ -118,7 +118,8 @@ class ManyBodyKeywords(ProtoModel):
         # definitive description. appended in Computer
         description="Dictionary of different levels of theory for different levels of expansion. Note that the primary "
             "method_string is not used when this keyword is given. ``supersystem`` computes all higher order n-body "
-            "effects up to the number of fragments. A method fills in for any lower unlisted nbody levels. Note that if "
+            "effects up to the number of fragments; this higher-order correction uses the nocp basis, regardless of "
+            "bsse_type. A method fills in for any lower unlisted nbody levels. Note that if "
             "both this and max_nbody are provided, they must be consistent. Examples: "
             "SUPERSYSTEM definition suspect"
             "* {1: 'ccsd(t)', 2: 'mp2', 'supersystem': 'scf'} "

--- a/qcmanybody/models/manybody_pydv1.py
+++ b/qcmanybody/models/manybody_pydv1.py
@@ -68,6 +68,20 @@ class BsseEnum(str, Enum):
     vmfc = "vmfc"  # Valiron-Mayer function counterpoise
     ssfc = "cp"
 
+    def formal(self):
+        return {
+            "nocp": "Non-Counterpoise Corrected",
+            "cp": "Counterpoise Corrected",
+            "vmfc": "Valiron-Mayer Function Counterpoise",
+        }[self]
+
+    def abbr(self):
+        return {
+            "nocp": "NoCP",
+            "cp": "CP",
+            "vmfc": "VMFC",
+        }[self]
+
 
 FragBasIndex = Tuple[Tuple[int], Tuple[int]]
 

--- a/qcmanybody/models/qcng_computer.py
+++ b/qcmanybody/models/qcng_computer.py
@@ -187,6 +187,7 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
         description=ManyBodyKeywords.__fields__["supersystem_ie_only"].field_info.description,
     )
     task_list: Dict[str, Any] = {}  #MBETaskComputers] = {}
+    #qcmb_calculator: Optional[Any] = None
 
     # TODO @computed_field(description="Number of distinct fragments comprising full molecular supersystem.")
     @property
@@ -368,7 +369,7 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
         return sio
 
     @classmethod
-    def from_qcschema_ben(cls, input_model: ManyBodyInput):
+    def from_qcschema_ben(cls, input_model: ManyBodyInput, build_tasks: bool = True):
 
         computer_model = cls(
             molecule=input_model.molecule,
@@ -406,8 +407,8 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
             computer_model.supersystem_ie_only,
         )
 
-        print("\n<<<  (ZZ 2) QCManyBody module ManyBodyCalculator  >>>")
-        print(dir(calculator_cls))
+        if not build_tasks:
+            return calculator_cls
 
         component_results = {}
 

--- a/qcmanybody/models/qcng_computer.py
+++ b/qcmanybody/models/qcng_computer.py
@@ -388,7 +388,8 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
         comp_levels = {}
         for mc_level_idx, mtd in enumerate(computer_model.levels.values()):
             for lvl1 in nb_per_mc[mc_level_idx]:
-                comp_levels[int(lvl1)] = mtd
+                key = "supersystem" if lvl1 == "supersystem" else int(lvl1)
+                comp_levels[key] = mtd
 
         specifications = {}
         for mtd, spec in computer_model.input_data.specification.specification.items():
@@ -743,6 +744,8 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
             ret_gradient = external_results.pop("ret_gradient", None)
             nbody_number = external_results.pop("nbody_number")
             component_properties = external_results.pop("component_properties")
+            stdout = external_results.pop("stdout")
+
 
         # load QCVariables
         qcvars = {
@@ -853,6 +856,7 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
                     'qcvars': qcvars,
                 },
                 'return_result': ret_ptype,
+                "stdout": stdout,
                 'success': True,
             })
 

--- a/qcmanybody/tests/test_mbe_he4_multilevel.py
+++ b/qcmanybody/tests/test_mbe_he4_multilevel.py
@@ -1,3 +1,4 @@
+import re
 import copy
 import pprint
 
@@ -237,6 +238,16 @@ he4_refs_conv_multilevel_631g = {
         "VMFC-CORRECTED 3-BODY CONTRIBUTION TO ENERGY":      -0.000238938400,
         "VMFC-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":       0.000058523922,
     },
+    "ss22": {
+        "CP-CORRECTED TOTAL ENERGY THROUGH 1-BODY":         -11.480648555603,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 2-BODY":         -11.470705938773,
+        "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY":         -11.470776016167,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY":     0.0,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY":     0.009942616831,
+        "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY":     0.009872539572,
+        "CP-CORRECTED 2-BODY CONTRIBUTION TO ENERGY":         0.009942616831,
+        "CP-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":        -0.000070079612,
+    }
 }
 
 # only here for keys
@@ -278,6 +289,107 @@ he4_refs_conv = {
         "VMFC-CORRECTED 4-BODY CONTRIBUTION TO ENERGY":         6.299342870974556e-05,
 }
 
+
+sumstr = {
+   "cp4b_tot": {
+       "121": r"""
+   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+
+^\s+n-Body     Total Energy            Interaction Energy                          N-body Contribution to Interaction Energy
+^\s+\[Eh\]                    \[Eh\]                  \[kcal/mol\]            \[Eh\]                  \[kcal/mol\]
+^\s+1\s+-11.4806485\d+        0.0000000\d+        0.00\d+        0.0000000\d+        0.00\d+
+^\s+2\s+-11.4710585\d+        0.0095899\d+        6.01\d+        0.0095899\d+        6.01\d+
+^\s+3\s+-11.4713246\d+        0.0093239\d+        5.85\d+       -0.0002660\d+       -0.16\d+
+^\s+FULL/RTN\s+4\s+-11.4712722\d+        0.0093763\d+        5.88\d+        0.0000523\d+        0.03\d+
+""",
+        "22": r"""
+   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+
+^\s+n-Body     Total Energy            Interaction Energy                          N-body Contribution to Interaction Energy
+^\s+\[Eh\]                    \[Eh\]                  \[kcal/mol\]            \[Eh\]                  \[kcal/mol\]
+^\s+1\s+-11.4806485\d+        0.0000000\d+        0.00\d+        0.0000000\d+        0.00\d+
+^\s+2\s+-11.4707059\d+        0.0099426\d+        6.23\d+        0.0099426\d+        6.23\d+
+^\s+3\s+-11.4709719\d+        0.0096765\d+        6.07\d+       -0.0002660\d+       -0.16\d+
+^\s+FULL/RTN\s+4\s+-11.4709134\d+        0.0097351\d+        6.10\d+        0.0000585\d+        0.03\d+
+""",
+        "ss22": r"""
+   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+
+^\s+n-Body     Total Energy            Interaction Energy                          N-body Contribution to Interaction Energy
+^\s+\[Eh\]                    \[Eh\]                  \[kcal/mol\]            \[Eh\]                  \[kcal/mol\]
+^\s+1\s+-11.4806485\d+        0.0000000\d+        0.00\d+        0.0000000\d+        0.00\d+
+^\s+2\s+-11.4707059\d+        0.0099426\d+        6.23\d+        0.0099426\d+        6.23\d+
+^\s+SS\s+3\s+N/A\s+N/A\s+N/A\s+N/A\s+N/A\s*
+^\s+SS/FULL/RTN\s+4      -11.4707760\d+        0.0098725\d+        6.19\d+       -0.0000700\d+       -0.04\d+
+""",
+   },
+   "cp3b_tot": {
+       "121": r"""
+   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+
+^\s+n-Body     Total Energy            Interaction Energy                          N-body Contribution to Interaction Energy
+^\s+\[Eh\]                    \[Eh\]                  \[kcal/mol\]            \[Eh\]                  \[kcal/mol\]
+^\s+1\s+-11.4806485\d+        0.0000000\d+        0.00\d+        0.0000000\d+        0.00\d+
+^\s+2\s+-11.4710585\d+        0.0095899\d+        6.01\d+        0.0095899\d+        6.01\d+
+^\s+RTN\s+3\s+-11.4713246\d+        0.0093239\d+        5.85\d+       -0.0002660\d+       -0.16\d+
+^\s+FULL\s+4\s+N/A                   N/A                   N/A                   N/A                   N/A\s*
+""",
+        "22": r"""
+   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+
+^\s+n-Body     Total Energy            Interaction Energy                          N-body Contribution to Interaction Energy
+^\s+\[Eh\]                    \[Eh\]                  \[kcal/mol\]            \[Eh\]                  \[kcal/mol\]
+^\s+1\s+-11.4806485\d+        0.0000000\d+        0.00\d+        0.0000000\d+        0.00\d+
+^\s+2\s+-11.4707059\d+        0.0099426\d+        6.23\d+        0.0099426\d+        6.23\d+
+^\s+RTN\s+3\s+-11.4709719\d+        0.0096765\d+        6.07\d+       -0.0002660\d+       -0.16\d+
+^\s+FULL\s+4\s+N/A                   N/A                   N/A                   N/A                   N/A\s*
+""",
+   },
+   "cp3b_ie": {
+       "121": r"""
+   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+
+^\s+n-Body     Total Energy            Interaction Energy                          N-body Contribution to Interaction Energy
+^\s+\[Eh\]                    \[Eh\]                  \[kcal/mol\]            \[Eh\]                  \[kcal/mol\]
+^\s+1\s+N/A\s+0.0000000\d+        0.00\d+        0.0000000\d+        0.00\d+
+^\s+2\s+N/A\s+0.0095899\d+        6.01\d+        0.0095899\d+        6.01\d+
+^\s+RTN\s+3\s+N/A\s+0.0093239\d+        5.85\d+       -0.0002660\d+       -0.16\d+
+^\s+FULL\s+4        N/A                   N/A                   N/A                   N/A                   N/A\s*
+""",
+        "22": r"""
+   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+
+^\s+n-Body     Total Energy            Interaction Energy                          N-body Contribution to Interaction Energy
+^\s+\[Eh\]                    \[Eh\]                  \[kcal/mol\]            \[Eh\]                  \[kcal/mol\]
+^\s+1\s+N/A\s+0.0000000\d+        0.00\d+        0.0000000\d+        0.00\d+
+^\s+2\s+N/A\s+0.0099426\d+        6.23\d+        0.0099426\d+        6.23\d+
+^\s+RTN\s+3\s+N/A\s+0.0096765\d+        6.07\d+       -0.0002660\d+       -0.16\d+
+^\s+FULL\s+4        N/A                   N/A                   N/A                   N/A                   N/A\s*
+""",
+   },
+   "cp2b_tot": {
+       "121": r"""
+   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+
+^\s+n-Body     Total Energy            Interaction Energy                          N-body Contribution to Interaction Energy
+^\s+\[Eh\]                    \[Eh\]                  \[kcal/mol\]            \[Eh\]                  \[kcal/mol\]
+^\s+1\s+-11.4806485\d+        0.0000000\d+        0.00\d+        0.0000000\d+        0.00\d+
+^\s+RTN\s+2\s+-11.4710585\d+        0.0095899\d+        6.01\d+        0.0095899\d+        6.01\d+
+^\s+3\s+N/A                   N/A                   N/A                   N/A                   N/A\s*
+^\s+FULL\s+4\s+N/A                   N/A                   N/A                   N/A                   N/A\s*
+""",
+        "22": r"""
+   ==> N-Body: Counterpoise Corrected \(CP\) energies <==
+
+^\s+n-Body     Total Energy            Interaction Energy                          N-body Contribution to Interaction Energy
+^\s+\[Eh\]                    \[Eh\]                  \[kcal/mol\]            \[Eh\]                  \[kcal/mol\]
+^\s+1\s+-11.4806485\d+        0.0000000\d+        0.00\d+        0.0000000\d+        0.00\d+
+^\s+RTN\s+2\s+-11.4707059\d+        0.0099426\d+        6.23\d+        0.0099426\d+        6.23\d+
+^\s+3\s+N/A                   N/A                   N/A                   N/A                   N/A\s*
+^\s+FULL\s+4\s+N/A                   N/A                   N/A                   N/A                   N/A\s*
+""",
+   },
+}
 
 sumdict_multi = {
     "4b_vmfc_rtd": {
@@ -334,7 +446,6 @@ def he_tetramer():
 @pytest.mark.parametrize("levels", [
     # pattern 121
     pytest.param({4: "c4-hf", 3: "c4-mp2", 1: "c4-ccsd"}, id="121-cfour_pure", marks=using("cfour")),
-    ##pytest.param({4: "gms-hf", 3: "gms-mp2", 1: "gms-ccsd"}, id="121-gamess_pure", marks=using("gamess")),
     pytest.param({4: "nwc-hf", 3: "nwc-mp2", 1: "nwc-ccsd"}, id="121-nwchem_pure", marks=using("nwchem")),
     pytest.param({4: "p4-hf", 3: "p4-mp2", 1: "p4-ccsd"}, id="121-psi4_pure", marks=using("psi4")),
 
@@ -344,11 +455,10 @@ def he_tetramer():
 
     # pattern 22
     pytest.param({4: "c4-mp2", 2: "c4-ccsd"}, id="22-cfour_pure", marks=using("cfour")),
-    ##pytest.param({4: "gms-mp2", 2: "gms-ccsd"}, id="22-gamess_pure", marks=using("gamess")),
     pytest.param({4: "nwc-mp2", 2: "nwc-ccsd"}, id="22-nwchem_pure", marks=using("nwchem")),
     pytest.param({4: "p4-mp2", 2: "p4-ccsd"}, id="22-psi4_pure", marks=using("psi4")),
 ])
-@pytest.mark.parametrize("mbe_keywords,anskey,bodykeys,calcinfo_nmbe", [
+@pytest.mark.parametrize("mbe_keywords,anskey,bodykeys,outstrs,calcinfo_nmbe", [
 #    pytest.param(
 #        {"bsse_type": ["nocp", "cp", "vmfc"]},
 #        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
@@ -360,6 +470,7 @@ def he_tetramer():
         {"bsse_type": ["nocp", "cp"]},
         "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if not k.startswith("VMFC-")],
+        None,
         {"121": 61,  # cp(14md + 15lo) + nocp(14md + 15lo) + 4hi - 1lo 1234@1234
          "22": 49},  # cp(10hi + 15lo) + nocp(10hi + 15lo) - 1lo 1234@1234
         id="4b_nocpcp"),
@@ -395,6 +506,7 @@ def he_tetramer():
         {"bsse_type": "nocp", "return_total_data": True},
         "NOCP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-"))],
+        None,
         {"121": 33,  # 4hi + 14md + 15lo vs. 15 for single-level
          "22": 25},  # 10hi + 15lo
         id="4b_nocp_rtd"),
@@ -402,6 +514,7 @@ def he_tetramer():
         {"bsse_type": "nocp", "return_total_data": False},
         "NOCP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-"))],
+        None,
         {"121": 33,  # could be 29 TODO,  # 14md + 15lo vs. 15 for single-level
          "22": 25},  # 10hi + 15lo
         id="4b_nocp"),
@@ -409,6 +522,7 @@ def he_tetramer():
         {"bsse_type": "cp", "return_total_data": True},
         "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-"))],
+        ["cp4b_tot"],
         {"121": 33,  # 4hi(nocp) + 14md + 15lo vs. 19 for single-level,
          "22": 29},  # 10hi + 15lo + 4hi(nocp)
         id="4b_cp_rtd"),
@@ -416,6 +530,7 @@ def he_tetramer():
         {"bsse_type": "cp", "return_total_data": False},
         "CP-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and "TOTAL ENERGY" not in k)],
+        None,
         {"121": 29, # 14md + 15lo vs. 15 for single-level,
          "22": 25},  # 10hi + 15lo
         id="4b_cp"),
@@ -423,6 +538,7 @@ def he_tetramer():
         {"bsse_type": "vmfc", "return_total_data": True},
         "VMFC-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("VMFC-"))],
+        None,
         {"121": 65,  # was 93 in p4  # 4hi + 18+28md + 15lo vs. 65 for single-level
          "22": 65},  # was 83 in p4  # 4+18hi + 28+15lo
         id="4b_vmfc_rtd"),
@@ -430,6 +546,7 @@ def he_tetramer():
         {"bsse_type": "vmfc", "return_total_data": False},
         "VMFC-CORRECTED INTERACTION ENERGY THROUGH 4-BODY",
         [k for k in he4_refs_conv if (k.startswith("VMFC-"))],
+        None,
         {"121": 65, # could be 61; was 93 in p4  # 18+28md + 15lo =61
          "22": 65}, # could be 61; was 83 in p4  # 18hi + 28+15lo = 61
         id="4b_vmfc"),
@@ -437,6 +554,7 @@ def he_tetramer():
         {"bsse_type": "nocp", "return_total_data": True, "max_nbody": 3},
         "NOCP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("4-BODY" not in k))],
+        None,
         {"121": 18,  # 4hi + 14md vs. 14 for single-level
          "22": 24},  # 10hi + 14lo
         id="3b_nocp_rtd"),
@@ -444,6 +562,7 @@ def he_tetramer():
         {"bsse_type": "nocp", "return_total_data": False, "max_nbody": 3},
         "NOCP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and "4-BODY" not in k)],
+        None,
         {"121": 18,  # 4hi + 14md vs. 14 for single-level
          "22": 24},  # 10hi + 14lo
         id="3b_nocp"),
@@ -451,6 +570,7 @@ def he_tetramer():
         {"bsse_type": "cp", "return_total_data": True, "max_nbody": 3},
         "CP-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and "4-BODY" not in k)],
+        ["cp3b_tot"],
         {"121": 18,  # 4hi + 14md vs. 18 for single-level  # bugfix: was 28
          "22": 28},  # 10hi + 14lo + 4hi(nocp)
         id="3b_cp_rtd"),
@@ -458,6 +578,7 @@ def he_tetramer():
         {"bsse_type": "cp", "return_total_data": False, "max_nbody": 3},
         "CP-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and "4-BODY" not in k and "TOTAL ENERGY" not in k)],
+        ["cp3b_ie"],
         {"121": 14,  # 14md vs. 14 for single-level
          "22": 24},  # 10hi + 14lo
         id="3b_cp"),
@@ -465,6 +586,7 @@ def he_tetramer():
         {"bsse_type": "vmfc", "return_total_data": True, "max_nbody": 3},
         "VMFC-CORRECTED TOTAL ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("VMFC-") and ("4-BODY" not in k))],
+        None,
         {"121": 50,  # 4hi + 18+28md vs. 14? for single-level
          "22": 50},  # was 68 in p4  # 4+18hi + 28lo
         id="3b_vmfc_rtd"),
@@ -472,6 +594,7 @@ def he_tetramer():
         {"bsse_type": "vmfc", "return_total_data": False, "max_nbody": 3},
         "VMFC-CORRECTED INTERACTION ENERGY THROUGH 3-BODY",
         [k for k in he4_refs_conv if (k.startswith("VMFC-") and ("4-BODY" not in k))],
+        None,
         {"121": 50, # could be 46  # 18+28md =46
          "22": 50}, # could be 46; was 68 in p4  # 18hi + 28lo = 46
         id="3b_vmfc"),
@@ -479,6 +602,7 @@ def he_tetramer():
         {"bsse_type": "nocp", "return_total_data": True, "max_nbody": 2},
         "NOCP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
+        None,
         {"121": 14,  # 4hi + 10md vs. 10 for single-level
          "22": 10},  # 10hi
         id="2b_nocp_rtd"),
@@ -486,6 +610,7 @@ def he_tetramer():
         {"bsse_type": "nocp", "return_total_data": False, "max_nbody": 2},
         "NOCP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
+        None,
         {"121": 14,  # 4hi + 10md vs. 10 for single-level,
          "22": 10},  # 10hi
         id="2b_nocp"),
@@ -493,6 +618,7 @@ def he_tetramer():
         {"bsse_type": "cp", "return_total_data": True, "max_nbody": 2},
         "CP-CORRECTED TOTAL ENERGY THROUGH 2-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
+        ["cp2b_tot"],
         {"121": 14,  # 4hi + 10md vs. 14 for single-level,
          "22": 14},  # 10hi + 4hi(nocp)
         id="2b_cp_rtd"),
@@ -500,6 +626,7 @@ def he_tetramer():
         {"bsse_type": "ssfc", "return_total_data": False, "max_nbody": 2},
         "CP-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and ("4-BODY" not in k) and ("3-BODY" not in k) and "TOTAL ENERGY" not in k)],
+        None,
         {"121": 10,  # 10md vs. 10 for single-level,
          "22": 10},  # 10hi
         id="2b_cp"),
@@ -509,6 +636,7 @@ def he_tetramer():
         # "22" at 2-body is effectively single-level so nocp enabled ...
         {"121": [k for k in he4_refs_conv if (k.startswith("VMFC-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
          "22": [k for k in he4_refs_conv if ((k.startswith("VMFC-") or k.startswith("NOCP-")) and ("4-BODY" not in k) and ("3-BODY" not in k))]},
+         None,
         {"121": 22,  # 4hi + 18+28md + 15lo vs. 65 for single-level
          "22": 22},  # 4+18hi + 28+15lo
         id="2b_vmfc_rtd"),
@@ -517,6 +645,7 @@ def he_tetramer():
         "VMFC-CORRECTED INTERACTION ENERGY THROUGH 2-BODY",
         {"121": [k for k in he4_refs_conv if (k.startswith("VMFC-") and ("4-BODY" not in k) and ("3-BODY" not in k))],
          "22": [k for k in he4_refs_conv if ((k.startswith("VMFC-") or k.startswith("NOCP-")) and ("4-BODY" not in k) and ("3-BODY" not in k))]},
+         None,
         {"121": 22, # TODO could be 18  # 0+18hi = 18
          "22": 22}, # TODO could be 18  # 18hi = 18
         id="2b_vmfc"),
@@ -524,6 +653,7 @@ def he_tetramer():
         {"bsse_type": "nocp", "return_total_data": True, "max_nbody": 1},
         "NOCP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
         [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("1-BODY" in k))],
+        None,
         {"121": 4,  # 4hi
          "22": 4},
         id="1b_nocp_rtd"),
@@ -531,6 +661,7 @@ def he_tetramer():
         {"bsse_type": "nocp", "return_total_data": False, "max_nbody": 1},
        "NOCP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
        [k for k in he4_refs_conv if (k.startswith("NOCP-") and ("1-BODY" in k))],
+       None,
         {"121": 4,  # 4hi
          "22": 4},
         id="1b_nocp"),
@@ -538,6 +669,7 @@ def he_tetramer():
         {"bsse_type": "cp", "return_total_data": True, "max_nbody": 1},
         "CP-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and ("1-BODY" in k))],
+        None,
         {"121": 4,  # 4hi
          "22": 4},
         id="1b_cp_rtd"),
@@ -545,6 +677,7 @@ def he_tetramer():
         {"bsse_type": "cp", "return_total_data": False, "max_nbody": 1},
         "CP-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
         [k for k in he4_refs_conv if (k.startswith("CP-") and ("1-BODY" in k) and "TOTAL ENERGY" not in k)],
+        None,
         {"121": 0,
          "22": 0},
         id="1b_cp"),
@@ -553,6 +686,7 @@ def he_tetramer():
         "VMFC-CORRECTED TOTAL ENERGY THROUGH 1-BODY",
         # max_nbody=1 is effectively single-modelchem so NOCP available for free
         [k for k in he4_refs_conv if ((k.startswith("VMFC-") or k.startswith("NOCP-")) and ("1-BODY" in k))],
+        None,
         {"121": 4,  # 4hi
          "22": 4},
         id="1b_vmfc_rtd"),
@@ -560,11 +694,12 @@ def he_tetramer():
         {"bsse_type": "vmfc", "return_total_data": False, "max_nbody": 1},
         "VMFC-CORRECTED INTERACTION ENERGY THROUGH 1-BODY",
         [k for k in he4_refs_conv if ((k.startswith("VMFC-") or k.startswith("NOCP-")) and ("1-BODY" in k))],
+        None,
         {"121": 4, # TODO could be 0
          "22": 4}, # TODO could be 0
         id="1b_vmfc"),
 ])
-def test_nbody_he4_multi(levels, mbe_keywords, anskey, bodykeys, calcinfo_nmbe, he_tetramer, request, mbe_data_multilevel_631g):
+def test_nbody_he4_multi(levels, mbe_keywords, anskey, bodykeys, outstrs, calcinfo_nmbe, he_tetramer, request, mbe_data_multilevel_631g):
     _inner = request.node.name.split("[")[1].split("]")[0]
     kwdsln, pattern, progln = _inner.split("-")
 
@@ -589,13 +724,6 @@ def test_nbody_he4_multi(levels, mbe_keywords, anskey, bodykeys, calcinfo_nmbe, 
     mbe_data_multilevel_631g["molecule"] = he_tetramer
     mbe_data_multilevel_631g["specification"]["keywords"] = mbe_keywords
     mbe_model = ManyBodyInput(**mbe_data_multilevel_631g)
-
-    if "gamess" in progln:
-        with pytest.raises(ValueError) as exe:
-            # qcng: qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
-            ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
-        assert "GAMESS+QCEngine can't handle ghost atoms yet" in str(exe.value)
-        pytest.xfail("GAMESS can't do ghosts")
 
     # qcng: ret = qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
     ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
@@ -635,7 +763,107 @@ def test_nbody_he4_multi(levels, mbe_keywords, anskey, bodykeys, calcinfo_nmbe, 
         assert compare_values(ref, ret.extras["qcvars"][qcv], atol=atol, label=f"[e] qcvars {qcv}")
         assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[f] skprop {skp}")
     assert compare_values(ans, ret.return_result, atol=atol, label=f"[g] ret")
+
     assert ret.properties.calcinfo_nmbe == ref_nmbe, f"{ret.properties.calcinfo_nmbe=} != {ref_nmbe}"
+
+    if outstrs:
+        for stdoutkey in outstrs:
+            assert re.search(sumstr[stdoutkey][pattern], ret.stdout, re.MULTILINE), f"[j] N-Body pattern not found: {sumstr[stdoutkey][pattern]}"
+
+
+@pytest.mark.parametrize("levels", [
+    # pattern ss121
+    #pytest.param({4: "c4-hf", 3: "c4-mp2", 1: "c4-ccsd"}, id="121-cfour_pure", marks=using("cfour")),
+    #pytest.param({4: "nwc-hf", 3: "nwc-mp2", 1: "nwc-ccsd"}, id="121-nwchem_pure", marks=using("nwchem")),
+    #pytest.param({"supersystem": "p4-hf", 3: "p4-mp2", 1: "p4-ccsd"}, id="ss121-psi4_pure", marks=using("psi4")),
+
+    # pattern ss22
+    #pytest.param({4: "c4-mp2", 2: "c4-ccsd"}, id="22-cfour_pure", marks=using("cfour")),
+    #pytest.param({4: "nwc-mp2", 2: "nwc-ccsd"}, id="22-nwchem_pure", marks=using("nwchem")),
+    pytest.param({"supersystem": "p4-mp2", 2: "p4-ccsd"}, id="ss22-psi4_pure", marks=using("psi4")),
+])
+@pytest.mark.parametrize("mbe_keywords,anskey,bodykeys,outstrs,calcinfo_nmbe", [
+    pytest.param(
+        {"bsse_type": "cp", "return_total_data": True},
+        "CP-CORRECTED TOTAL ENERGY THROUGH 4-BODY",
+        [k for k in he4_refs_conv if (k.startswith("CP-"))],
+        ["cp4b_tot"],
+        {#"ss121": 0,
+         "ss22": 25},  # cp(10hi) + nocp(4hi + 11lo)
+        id="4b_cp_rtd"),
+])
+def test_nbody_he4_supersys(levels, mbe_keywords, anskey, bodykeys, outstrs, calcinfo_nmbe, he_tetramer, request, mbe_data_multilevel_631g):
+    _inner = request.node.name.split("[")[1].split("]")[0]
+    kwdsln, pattern, progln = _inner.split("-")
+
+    levels = copy.deepcopy(levels)
+    if pattern == "121":
+        if mbe_keywords.get("max_nbody", 4) == 3:
+            del levels[4]  # max_nbody and levels silently contradict w/o this
+        elif mbe_keywords.get("max_nbody", 4) == 2:
+            levels = {2: levels[3], 1: levels[1]}
+        elif mbe_keywords.get("max_nbody", 4) == 1:
+            del levels[4]
+            del levels[3]
+    elif pattern == "22":
+        if mbe_keywords.get("max_nbody", 4) == 3:
+            levels = {3: levels[4], 2: levels[2]}
+        if mbe_keywords.get("max_nbody", 4) == 2:
+            del levels[4]
+        if mbe_keywords.get("max_nbody", 4) == 1:
+            levels = {1: levels[2]}
+
+    mbe_keywords = ManyBodyKeywords(levels=levels, **mbe_keywords)
+    mbe_data_multilevel_631g["molecule"] = he_tetramer
+    mbe_data_multilevel_631g["specification"]["keywords"] = mbe_keywords
+    mbe_model = ManyBodyInput(**mbe_data_multilevel_631g)
+
+    # qcng: ret = qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
+    ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
+    print(f"MMMMMMM {request.node.name}")
+    pprint.pprint(ret.dict(), width=200)
+
+    refs = he4_refs_conv_multilevel_631g[pattern]
+    ans = refs[anskey]
+    ref_nmbe = calcinfo_nmbe[pattern]
+    ref_bodykeys = bodykeys[pattern] if pattern in bodykeys else bodykeys
+    ref_sumdict = sumdict[kwdsln][pattern] if pattern in sumdict[kwdsln] else sumdict[kwdsln]
+    atol = 2.5e-8
+
+    for qcv, ref in refs.items():
+        skp = skprop(qcv)
+        if qcv in ref_bodykeys:
+            assert compare_values(ref, ret.extras["qcvars"]["nbody"][qcv], atol=atol, label=f"[a] qcvars {qcv}")
+            assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[b] skprop {skp}")
+        else:
+            assert qcv not in ret.extras["qcvars"]["nbody"], f"[z] {qcv=} wrongly present"
+            assert getattr(ret.properties, skp) is None
+
+    for qcv in sumdict["4b_all"]:
+        skp = skprop(qcv)
+        if qcv in ref_sumdict:
+            ref = refs[ref_sumdict[qcv]]
+            assert compare_values(ref, ret.extras["qcvars"]["nbody"][qcv], atol=atol, label=f"[c] qcvars {qcv}")
+            assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[d] skprop {skp}")
+        else:
+            assert qcv not in ret.extras["qcvars"]["nbody"], f"[y] {qcv=} wrongly present"
+            assert getattr(ret.properties, skp) is None
+
+    for qcv, ref in {
+        "CURRENT ENERGY": ans,
+    }.items():
+        skp = skprop(qcv)
+        assert compare_values(ref, ret.extras["qcvars"][qcv], atol=atol, label=f"[e] qcvars {qcv}")
+        assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[f] skprop {skp}")
+    assert compare_values(ans, ret.return_result, atol=atol, label=f"[g] ret")
+
+    assert ret.properties.calcinfo_nmbe == ref_nmbe, f"{ret.properties.calcinfo_nmbe=} != {ref_nmbe}"
+
+    if outstrs:
+        for stdoutkey in outstrs:
+            print(stdoutkey)
+            print(sumstr[stdoutkey][pattern])
+            assert re.search(sumstr[stdoutkey][pattern], ret.stdout, re.MULTILINE), f"[j] N-Body pattern not found: {sumstr[stdoutkey][pattern]}"
 
 
 @pytest.mark.parametrize("mbe_keywords,ref_count", [

--- a/qcmanybody/tests/test_mbe_he4_multilevel.py
+++ b/qcmanybody/tests/test_mbe_he4_multilevel.py
@@ -6,7 +6,7 @@ import pytest
 from qcelemental import constants
 from qcelemental.models import Molecule
 # v2: from qcelemental.models.procedures_manybody import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
-from qcelemental.testing import compare_values
+from qcelemental.testing import compare_values, compare_recursive
 
 from qcmanybody.models.manybody_pydv1 import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
 from qcmanybody.models.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
@@ -636,3 +636,42 @@ def test_nbody_he4_multi(levels, mbe_keywords, anskey, bodykeys, calcinfo_nmbe, 
         assert compare_values(ref, getattr(ret.properties, skp), atol=atol, label=f"[f] skprop {skp}")
     assert compare_values(ans, ret.return_result, atol=atol, label=f"[g] ret")
     assert ret.properties.calcinfo_nmbe == ref_nmbe, f"{ret.properties.calcinfo_nmbe=} != {ref_nmbe}"
+
+
+@pytest.mark.parametrize("mbe_keywords,ref_count", [
+    pytest.param(
+        {"bsse_type": ["nocp", "cp", "vmfc"], "levels": {4: "c4-mp2", 2: "c4-ccsd"},},
+        {"all": {"c4-ccsd": {2: 12, 1: 20}, "c4-mp2": {4: 1, 3: 8, 2: 24, 1: 20}},
+         "cp": {"c4-ccsd": {2: 6, 1: 4}, "c4-mp2": {4: 1, 3: 4, 2: 6, 1: 4}},
+         "nocp": {"c4-ccsd": {2: 6, 1: 4}, "c4-mp2": {4: 1, 3: 4, 2: 6, 1: 4}},
+         "vmfc_compute": {"c4-ccsd": {2: 6, 1: 16}, "c4-mp2": {4: 1, 3: 8, 2: 18, 1: 16}},
+         },
+        id="4b_all"),
+    pytest.param(
+        {"bsse_type": "cp", "return_total_data": True, "max_nbody": 3, "levels": {3: "c4-mp2", 2: "c4-ccsd"},},
+        {"all": {"c4-ccsd": {1: 8, 2: 6}, "c4-mp2": {1: 4, 2: 6, 3: 4}},
+         "cp": {"c4-ccsd": {1: 4, 2: 6}, "c4-mp2": {1: 4, 2: 6, 3: 4}},
+         "nocp": {"c4-ccsd": {1: 4}, "c4-mp2": {}},
+         "vmfc_compute": {"c4-ccsd": {}, "c4-mp2": {}},
+        },
+        id="3b_cp_rtd"),
+   pytest.param(
+       {"bsse_type": "vmfc", "return_total_data": False, "max_nbody": 3, "levels": {3: "c4-mp2", 2: "c4-ccsd"},},
+       {"all": {"c4-ccsd": {2: 6, 1: 16}, "c4-mp2": {3: 4, 2: 12, 1: 12}},
+         "cp": {"c4-ccsd": {}, "c4-mp2": {}},
+         "nocp": {"c4-ccsd": {}, "c4-mp2": {}},  # no free nocp with vmfc for multilevel
+         "vmfc_compute": {"c4-ccsd": {2: 6, 1: 16}, "c4-mp2": {3: 4, 2: 12, 1: 12}},
+       },
+       id="3b_vmfc"),
+])
+def test_count_he4_multi(mbe_keywords, ref_count, he_tetramer, request):
+    atomic_spec = AtomicSpecification(model={"method": "mp2", "basis": "mybas"}, program="myqc", driver="energy")
+    mbe_model = ManyBodyInput(specification={"specification": atomic_spec, "keywords": mbe_keywords, "driver": "energy"}, molecule=he_tetramer)
+
+    ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model, build_tasks=False)
+
+    text, dcount = ret.format_calc_plan()
+    assert compare_recursive(ref_count["all"], dcount, atol=1.e-6)
+    for sset in ["all", "cp", "nocp", "vmfc_compute"]:
+        text, dcount = ret.format_calc_plan(sset)
+        assert compare_recursive(ref_count[sset], dcount, atol=1.e-6)

--- a/qcmanybody/tests/test_mbe_keywords.py
+++ b/qcmanybody/tests/test_mbe_keywords.py
@@ -191,7 +191,7 @@ def test_mbe_level_5mer(mbe_data, kws, ans):
     pytest.param({"max_nbody": -1}, "should be between 1 and 3"),
     pytest.param({"max_nbody": 4}, "should be between 1 and 3"),
     # fails on v1 b/c val 2 coerced to a str  pytest.param({"levels": {1: 2, 3: "mp2", 2: "ccsd"}}, "asdf"),  # `1: 2 is old syntax and doesn't pass typing
-    pytest.param({"max_nbody": 1, "supersystem_ie_only": True}, "Cannot skip intermediate n-body jobs")
+    pytest.param({"max_nbody": 1, "supersystem_ie_only": True}, "Cannot skip intermediate n-body jobs"),
     # [3, supersystem]
 ])
 def test_mbe_level_fails(mbe_data, kws, errmsg):
@@ -202,7 +202,7 @@ def test_mbe_level_fails(mbe_data, kws, errmsg):
         input_model = ManyBodyInput(**mbe_data)
         ManyBodyComputerQCNG.from_qcschema(input_model)
 
-    assert errmsg in str(e.value)
+    assert errmsg in str(e.value), e.value
 
 
 @pytest.mark.parametrize("kws,ans", [

--- a/qcmanybody/utils.py
+++ b/qcmanybody/utils.py
@@ -243,11 +243,11 @@ def delabeler(item: str) -> Tuple[str, Tuple[int, ...], Tuple[int, ...]]:
 
 
 def print_nbody_energy(
-    energy_body_dict: Dict[int, float],
+    energy_body_dict: Mapping[int, float],
     header: str,
     nfragments: int,
     embedding: bool = False,
-):
+) -> str:
     """Format output string for user for a single bsse_type. Prints to output and logger.
     Called repeatedly by assemble_nbody_component."""
 
@@ -285,6 +285,7 @@ def print_nbody_energy(
 
     info += "\n"
     print(info)
+    return info
 
 
 def collect_vars(


### PR DESCRIPTION
- [x] add a calc counter interface, mostly for printing. add tests for single and multi
- [x] save a stdout in the analyze return
- [x] capture main table printing to check against
  - [x] fix supersystem_ie_only printing that has big wrong numbers
  - [x] add a SS label for levels=supersystem printing, so its clearer why there's a N/A row
  - [x] removed the contrib col for supersystem_ie_only
  - [x] fixed up spacing
- [x] added testing for a multilevel with supersystem
- [x] saved correct qcvars for has_supersystem

If the saved tests are failing, my suspicion is that TOTAL ENERGY was getting saved to the max_nbody val rather than the nfr val for levels w/supersys calcs.