### PR TITLE
fix test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,17 @@ jobs:
         pip install -e .
         # python -m pip install . --no-deps  # gives no codecov beyond tests
 
+    - name: Configure QCEngine
+      run: |
+        cat > qcengine.yaml <<EOF
+        all:
+          hostname_pattern: "*"
+          memory: 2
+          ncores: 2
+        EOF
+        cat qcengine.yaml
+        qcengine info
+
     - name: PyTest
       run: |
         pytest -rws -v ${{ matrix.cfg.pytest }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
             - pytest-cov
             - codecov
             # Testing CMS
-            - psi4
+            - psi4=1.9.1
             #- nwchem  # lands on different he4 soln
             #- networkx
           EOF


### PR DESCRIPTION
Ok, the real CI trouble was that it started pulling psi4 1.9 and that's not compatible (different AM) with the latest L2. Insist upon 1.9.1. But on the way there, I added a file to restrict the memory and number of nodes, which I sometimes need locally for when psi4 tries to allocate all the memory for each test.