### PR TITLE
prune qcng_computer

### DIFF
--- a/qcmanybody/models/__init__.py
+++ b/qcmanybody/models/__init__.py
@@ -1,8 +1,12 @@
-from .manybody_pydv1 import (
+from .manybody_input_pydv1 import (
+    AtomicSpecification,
     BsseEnum,
     FragBasIndex,
     ManyBodyInput,
     ManyBodyKeywords,
+)
+from .manybody_output_pydv1 import (
     ManyBodyResult,
     ManyBodyResultProperties,
+    MAX_NBODY
 )

--- a/qcmanybody/models/manybody_input_pydv1.py
+++ b/qcmanybody/models/manybody_input_pydv1.py
@@ -58,6 +58,34 @@ class SuccessfulResultBase(ResultBase):
     success: Literal[True] = Field(True, description="Always `True` for a successful result")
 
 
+# ====  Protocols  ==============================================================
+
+class ManyBodyProtocolEnum(str, Enum):
+    """
+    Which atomic evaluations to keep in a many body evaluation.
+    """
+
+    all = "all"
+    all_real = "all_real"
+    largest_body = "largest_body"
+    none = "none"
+
+
+class ManyBodyProtocols(ProtoModel):
+    """
+    Protocols regarding the manipulation of a ManyBody output data.
+    """
+
+    atomics: ManyBodyProtocolEnum = Field(
+        ManyBodyProtocolEnum.all,
+        description=str(ManyBodyProtocolEnum.__doc__),
+    )
+
+    # v2: model_config = ExtendedConfigDict(force_skip_defaults=True)
+    class Config:
+        force_skip_defaults = True
+
+
 # ====  Inputs  =================================================================
 
 class BsseEnum(str, Enum):
@@ -166,6 +194,7 @@ class ManyBodyKeywords(ProtoModel):
 
 
 class ManyBodySpecification(ProtoModel):
+    """Combining the what (ManyBodyKeywords) with the how (AtomicSpecification)."""
 
     schema_name: Literal["qcschema_manybodyspecification"] = "qcschema_manybodyspecification"
     #provenance: Provenance = Field(Provenance(**provenance_stamp(__name__)), description=Provenance.__doc__)
@@ -194,6 +223,7 @@ class ManyBodySpecification(ProtoModel):
 
 
 class ManyBodyInput(ProtoModel):
+    """Combining the what and how (ManyBodySpecification) with the who (Molecule)."""
 
     schema_name: Literal["qcschema_manybodyinput"] = "qcschema_manybodyinput"
     #provenance: Provenance = Field(Provenance(**provenance_stamp(__name__)), description=Provenance.__doc__)
@@ -206,31 +236,3 @@ class ManyBodyInput(ProtoModel):
         description="Target molecule for many-body expansion (MBE) or interaction energy (IE) analysis.",
     )
     #protocols
-
-
-# ====  Protocols  ==============================================================
-
-class ManyBodyProtocolEnum(str, Enum):
-    """
-    Which atomic evaluations to keep in a many body evaluation.
-    """
-
-    all = "all"
-    all_real = "all_real"
-    largest_body = "largest_body"
-    none = "none"
-
-
-class ManyBodyProtocols(ProtoModel):
-    """
-    Protocols regarding the manipulation of a ManyBody output data.
-    """
-
-    atomics: ManyBodyProtocolEnum = Field(
-        ManyBodyProtocolEnum.all,
-        description=str(ManyBodyProtocolEnum.__doc__),
-    )
-
-    # v2: model_config = ExtendedConfigDict(force_skip_defaults=True)
-    class Config:
-        force_skip_defaults = True

--- a/qcmanybody/models/manybody_input_pydv1.py
+++ b/qcmanybody/models/manybody_input_pydv1.py
@@ -1,0 +1,236 @@
+
+from __future__ import annotations
+
+from enum import Enum, IntEnum
+from typing import Any, Dict, List, Optional, Literal, Tuple, Union, TYPE_CHECKING
+
+# v2: from pydantic import create_model, Field, field_validator, FieldValidationInfo
+try:
+    from pydantic.v1 import create_model, Field, validator
+except ImportError:
+    from pydantic import create_model, Field, validator
+
+from qcelemental.models.types import Array
+#from .basemodels import ExtendedConfigDict, ProtoModel
+from qcelemental.models.common_models import Model
+from qcelemental.models.molecule import Molecule
+from qcelemental.models.results import AtomicResultProperties, AtomicResultProtocols
+from qcelemental.models import DriverEnum, ProtoModel, Provenance
+
+
+# ====  Misplaced & Next Models  ================================================
+
+class AtomicSpecification(ProtoModel):
+    """Specification for a single point QC calculation"""
+
+    keywords: Dict[str, Any] = Field({}, description="The program specific keywords to be used.")
+    program: str = Field(..., description="The program for which the Specification is intended.")
+
+    schema_name: Literal["qcschema_atomicspecification"] = "qcschema_atomicspecification"
+    driver: DriverEnum = Field(..., description=DriverEnum.__doc__)
+    model: Model = Field(..., description=Model.__doc__)
+    protocols: AtomicResultProtocols = Field(
+        AtomicResultProtocols(),
+        description=AtomicResultProtocols.__doc__,
+    )
+
+
+class ResultBase(ProtoModel):
+    """Base class for all result classes"""
+
+    #input_data: InputBase = Field(..., description=InputBase.__doc__)
+    input_data: Any
+    success: bool = Field(
+        ...,
+        description="A boolean indicator that the operation succeeded or failed. Allows programmatic assessment of "
+        "all results regardless of if they failed or succeeded by checking `result.success`.",
+    )
+    stdout: Optional[str] = Field(
+        None,
+        description="The primary logging output of the program, whether natively standard output or a file. Presence vs. absence (or null-ness?) configurable by protocol.",
+    )
+    stderr: Optional[str] = Field(None, description="The standard error of the program execution.")
+
+
+class SuccessfulResultBase(ResultBase):
+    """Base object for any successful result"""
+
+    success: Literal[True] = Field(True, description="Always `True` for a successful result")
+
+
+# ====  Inputs  =================================================================
+
+class BsseEnum(str, Enum):
+    """Available basis-set superposition error (BSSE) treatments."""
+
+    nocp = "nocp"  # plain supramolecular interaction energy
+    cp = "cp"      # Boys-Bernardi counterpoise correction; site-site functional counterpoise (SSFC)
+    vmfc = "vmfc"  # Valiron-Mayer function counterpoise
+    ssfc = "cp"
+
+    def formal(self):
+        return {
+            "nocp": "Non-Counterpoise Corrected",
+            "cp": "Counterpoise Corrected",
+            "vmfc": "Valiron-Mayer Function Counterpoise",
+        }[self]
+
+    def abbr(self):
+        return {
+            "nocp": "NoCP",
+            "cp": "CP",
+            "vmfc": "VMFC",
+        }[self]
+
+
+FragBasIndex = Tuple[Tuple[int], Tuple[int]]
+
+
+class ManyBodyKeywords(ProtoModel):
+    """The many-body-specific keywords for user control."""
+
+    bsse_type: List[BsseEnum] = Field(
+        [BsseEnum.cp],
+        # definitive description
+        description="Requested BSSE treatments. First in list determines which interaction or total "
+            "energy/gradient/Hessian returned.",
+    )
+    embedding_charges: Dict[int, List[float]] = Field(
+        {},
+        description="Atom-centered point charges to be used on molecule fragments whose basis sets are not included in "
+            "the computation. Keys: 1-based index of fragment. Values: list of atom charges for that fragment.",
+            # TODO embedding charges should sum to fragment charge, right? enforce?
+            # TODO embedding charges irrelevant to CP (basis sets always present)?
+        json_schema_extra={
+            "shape": ["nfr", "<varies: nat in ifr>"],
+        },
+    )
+    return_total_data: Optional[bool] = Field(
+        None,
+        validate_default=True,
+        # definitive description
+        description="When True, returns the total data (energy/gradient/Hessian) of the system, otherwise returns "
+            "interaction data. Default is False for energies, True for gradients and Hessians. Note that the calculation "
+            "of counterpoise corrected total energies implies the calculation of the energies of monomers in the monomer "
+            "basis, hence specifying ``return_total_data = True`` may carry out more computations than "
+            "``return_total_data = False``. For gradients and Hessians, ``return_total_data = False`` is rarely useful.",
+    )
+    levels: Optional[Dict[Union[int, Literal["supersystem"]], str]] = Field(
+        None,
+        # definitive description. appended in Computer
+        description="Dictionary of different levels of theory for different levels of expansion. Note that the primary "
+            "method_string is not used when this keyword is given. ``supersystem`` computes all higher order n-body "
+            "effects up to the number of fragments; this higher-order correction uses the nocp basis, regardless of "
+            "bsse_type. A method fills in for any lower unlisted nbody levels. Note that if "
+            "both this and max_nbody are provided, they must be consistent. Examples: "
+            "SUPERSYSTEM definition suspect"
+            "* {1: 'ccsd(t)', 2: 'mp2', 'supersystem': 'scf'} "
+            "* {2: 'ccsd(t)/cc-pvdz', 3: 'mp2'} "
+            "* Now invalid: {1: 2, 2: 'ccsd(t)/cc-pvdz', 3: 'mp2'} ",
+    )
+    max_nbody: Optional[int] = Field(
+        None,
+        validate_default=True,
+        # definitive description
+        description="Maximum number of bodies to include in the many-body treatment. Possible: max_nbody <= nfragments. "
+            "Default: max_nbody = nfragments.",
+    )
+    supersystem_ie_only: Optional[bool] = Field(
+        False,
+        validate_default=True,
+        # definitive description
+        description="Target the supersystem total/interaction energy (IE) data over the many-body expansion (MBE) "
+            "analysis, thereby omitting intermediate-body calculations. When False (default), compute each n-body level "
+            "in the MBE up through ``max_nbody``. When True (only allowed for ``max_nbody = nfragments``), only compute "
+            "enough for the overall interaction/total energy: max_nbody-body and 1-body. When True, properties "
+            "``INTERACTION {driver} THROUGH {max_nbody}-BODY`` will always be available; ``TOTAL {driver} THROUGH "
+            "{max_nbody}-BODY`` will be available depending on ``return_total_data``; and ``{max_nbody}-BODY "
+            "CONTRIBUTION TO {driver}`` won't be available (except for dimers). This keyword produces no savings for a "
+            "two-fragment molecule. But for the interaction energy of a three-fragment molecule, for example, 2-body "
+            "subsystems can be skipped with ``supersystem_ie_only=True`` Do not use with ``vmfc`` in ``bsse_type``"
+            "as it cannot produce savings."
+    )
+
+    # v2: @field_validator("bsse_type", mode="before")
+    @validator("bsse_type", pre=True)
+    @classmethod
+    def set_bsse_type(cls, v: Any) -> List[BsseEnum]:
+        if not isinstance(v, list):
+            v = [v]
+        # emulate ordered set
+        # * bt.lower() as return (w/i `list(dict.fromkeys([bt.lower() ...`)
+        #   works until aliases added to BsseEnum
+        # * BsseEnum[bt].value as return works for good vals, but passing bad
+        #   vals through as bt lets pydantic raise a clearer error message
+        return list(dict.fromkeys([(BsseEnum[bt.lower()].value if bt.lower() in BsseEnum.__members__ else bt.lower()) for bt in v]))
+
+
+class ManyBodySpecification(ProtoModel):
+
+    schema_name: Literal["qcschema_manybodyspecification"] = "qcschema_manybodyspecification"
+    #provenance: Provenance = Field(Provenance(**provenance_stamp(__name__)), description=Provenance.__doc__)
+    keywords: ManyBodyKeywords = Field(..., description=ManyBodyKeywords.__doc__)
+    #program: str = Field(..., description="The program for which the Specification is intended.")
+    driver: DriverEnum = Field(
+        ...,
+        description="The computation driver; i.e., energy, gradient, hessian.",
+    )
+    #specification: Union[AtomicSpecification, Dict[str, AtomicSpecification]] = Field(
+    specification: Dict[str, AtomicSpecification] = Field(
+        ...,
+        description="??? TODO expand to cbs, fd",
+    )
+
+    # v2: @field_validator("specification", mode="before")
+    @validator("specification", pre=True)
+    @classmethod
+    def set_specification(cls, v: Any) -> Dict[str, AtomicSpecification]:
+        #print(f"hit atomicspecification validator with {type(v)=} {v}", end="")
+        # v could be model instance or dict
+        if isinstance(v, AtomicSpecification) or "model" in v:
+            v = {"(auto)": v}
+        #print(f" ... setting v={v}")
+        return v
+
+
+class ManyBodyInput(ProtoModel):
+
+    schema_name: Literal["qcschema_manybodyinput"] = "qcschema_manybodyinput"
+    #provenance: Provenance = Field(Provenance(**provenance_stamp(__name__)), description=Provenance.__doc__)
+    specification: ManyBodySpecification = Field(
+        ...,
+        description="???",
+    )
+    molecule: Molecule = Field(
+        ...,
+        description="Target molecule for many-body expansion (MBE) or interaction energy (IE) analysis.",
+    )
+    #protocols
+
+
+# ====  Protocols  ==============================================================
+
+class ManyBodyProtocolEnum(str, Enum):
+    """
+    Which atomic evaluations to keep in a many body evaluation.
+    """
+
+    all = "all"
+    all_real = "all_real"
+    largest_body = "largest_body"
+    none = "none"
+
+
+class ManyBodyProtocols(ProtoModel):
+    """
+    Protocols regarding the manipulation of a ManyBody output data.
+    """
+
+    atomics: ManyBodyProtocolEnum = Field(
+        ManyBodyProtocolEnum.all,
+        description=str(ManyBodyProtocolEnum.__doc__),
+    )
+
+    # v2: model_config = ExtendedConfigDict(force_skip_defaults=True)
+    class Config:
+        force_skip_defaults = True

--- a/qcmanybody/models/manybody_output_pydv1.py
+++ b/qcmanybody/models/manybody_output_pydv1.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum, IntEnum
-from typing import Any, Dict, List, Optional, Literal, Tuple, Union, TYPE_CHECKING
+from typing import Any, Dict, Literal, Optional, TYPE_CHECKING, Union
 
 # v2: from pydantic import create_model, Field, field_validator, FieldValidationInfo
 try:
@@ -10,230 +9,10 @@ except ImportError:
     from pydantic import create_model, Field, validator
 
 from qcelemental.models.types import Array
-#from .basemodels import ExtendedConfigDict, ProtoModel
-from qcelemental.models.common_models import Model
-from qcelemental.models.molecule import Molecule
-from qcelemental.models.results import AtomicResultProperties, AtomicResultProtocols
-from qcelemental.models import DriverEnum, ProtoModel, Provenance
+from qcelemental.models.results import AtomicResultProperties #, AtomicResultProtocols
+from qcelemental.models import ProtoModel, Provenance
 
-
-# ====  Misplaced & Next Models  ================================================
-
-class AtomicSpecification(ProtoModel):
-    """Specification for a single point QC calculation"""
-
-    keywords: Dict[str, Any] = Field({}, description="The program specific keywords to be used.")
-    program: str = Field(..., description="The program for which the Specification is intended.")
-
-    schema_name: Literal["qcschema_atomicspecification"] = "qcschema_atomicspecification"
-    driver: DriverEnum = Field(..., description=DriverEnum.__doc__)
-    model: Model = Field(..., description=Model.__doc__)
-    protocols: AtomicResultProtocols = Field(
-        AtomicResultProtocols(),
-        description=AtomicResultProtocols.__doc__,
-    )
-
-
-class ResultBase(ProtoModel):
-    """Base class for all result classes"""
-
-    #input_data: InputBase = Field(..., description=InputBase.__doc__)
-    input_data: Any
-    success: bool = Field(
-        ...,
-        description="A boolean indicator that the operation succeeded or failed. Allows programmatic assessment of "
-        "all results regardless of if they failed or succeeded by checking `result.success`.",
-    )
-    stdout: Optional[str] = Field(
-        None,
-        description="The primary logging output of the program, whether natively standard output or a file. Presence vs. absence (or null-ness?) configurable by protocol.",
-    )
-    stderr: Optional[str] = Field(None, description="The standard error of the program execution.")
-
-
-class SuccessfulResultBase(ResultBase):
-    """Base object for any successful result"""
-
-    success: Literal[True] = Field(True, description="Always `True` for a successful result")
-
-
-# ====  Inputs  =================================================================
-
-class BsseEnum(str, Enum):
-#class BsseEnum(IntEnum):
-    """Available basis-set superposition error (BSSE) treatments."""
-
-    nocp = "nocp"  # plain supramolecular interaction energy
-    cp = "cp"      # Boys-Bernardi counterpoise correction; site-site functional counterpoise (SSFC)
-    vmfc = "vmfc"  # Valiron-Mayer function counterpoise
-    ssfc = "cp"
-
-    def formal(self):
-        return {
-            "nocp": "Non-Counterpoise Corrected",
-            "cp": "Counterpoise Corrected",
-            "vmfc": "Valiron-Mayer Function Counterpoise",
-        }[self]
-
-    def abbr(self):
-        return {
-            "nocp": "NoCP",
-            "cp": "CP",
-            "vmfc": "VMFC",
-        }[self]
-
-
-FragBasIndex = Tuple[Tuple[int], Tuple[int]]
-
-
-class ManyBodyKeywords(ProtoModel):
-    """The many-body-specific keywords for user control."""
-
-    bsse_type: List[BsseEnum] = Field(
-        [BsseEnum.cp],
-        # definitive description
-        description="Requested BSSE treatments. First in list determines which interaction or total "
-            "energy/gradient/Hessian returned.",
-    )
-    embedding_charges: Dict[int, List[float]] = Field(
-        {},
-        description="Atom-centered point charges to be used on molecule fragments whose basis sets are not included in "
-            "the computation. Keys: 1-based index of fragment. Values: list of atom charges for that fragment.",
-            # TODO embedding charges should sum to fragment charge, right? enforce?
-            # TODO embedding charges irrelevant to CP (basis sets always present)?
-        json_schema_extra={
-            "shape": ["nfr", "<varies: nat in ifr>"],
-        },
-    )
-    return_total_data: Optional[bool] = Field(
-        None,
-        validate_default=True,
-        # definitive description
-        description="When True, returns the total data (energy/gradient/Hessian) of the system, otherwise returns "
-            "interaction data. Default is False for energies, True for gradients and Hessians. Note that the calculation "
-            "of counterpoise corrected total energies implies the calculation of the energies of monomers in the monomer "
-            "basis, hence specifying ``return_total_data = True`` may carry out more computations than "
-            "``return_total_data = False``. For gradients and Hessians, ``return_total_data = False`` is rarely useful.",
-    )
-    levels: Optional[Dict[Union[int, Literal["supersystem"]], str]] = Field(
-        None,
-        # definitive description. appended in Computer
-        description="Dictionary of different levels of theory for different levels of expansion. Note that the primary "
-            "method_string is not used when this keyword is given. ``supersystem`` computes all higher order n-body "
-            "effects up to the number of fragments; this higher-order correction uses the nocp basis, regardless of "
-            "bsse_type. A method fills in for any lower unlisted nbody levels. Note that if "
-            "both this and max_nbody are provided, they must be consistent. Examples: "
-            "SUPERSYSTEM definition suspect"
-            "* {1: 'ccsd(t)', 2: 'mp2', 'supersystem': 'scf'} "
-            "* {2: 'ccsd(t)/cc-pvdz', 3: 'mp2'} "
-            "* Now invalid: {1: 2, 2: 'ccsd(t)/cc-pvdz', 3: 'mp2'} ",
-    )
-    max_nbody: Optional[int] = Field(
-        None,
-        validate_default=True,
-        # definitive description
-        description="Maximum number of bodies to include in the many-body treatment. Possible: max_nbody <= nfragments. "
-            "Default: max_nbody = nfragments.",
-    )
-    supersystem_ie_only: Optional[bool] = Field(
-        False,
-        validate_default=True,
-        # definitive description
-        description="Target the supersystem total/interaction energy (IE) data over the many-body expansion (MBE) "
-            "analysis, thereby omitting intermediate-body calculations. When False (default), compute each n-body level "
-            "in the MBE up through ``max_nbody``. When True (only allowed for ``max_nbody = nfragments``), only compute "
-            "enough for the overall interaction/total energy: max_nbody-body and 1-body. When True, properties "
-            "``INTERACTION {driver} THROUGH {max_nbody}-BODY`` will always be available; ``TOTAL {driver} THROUGH "
-            "{max_nbody}-BODY`` will be available depending on ``return_total_data``; and ``{max_nbody}-BODY "
-            "CONTRIBUTION TO {driver}`` won't be available (except for dimers). This keyword produces no savings for a "
-            "two-fragment molecule. But for the interaction energy of a three-fragment molecule, for example, 2-body "
-            "subsystems can be skipped with ``supersystem_ie_only=True`` Do not use with ``vmfc`` in ``bsse_type``"
-            "as it cannot produce savings."
-    )
-
-    # v2: @field_validator("bsse_type", mode="before")
-    @validator("bsse_type", pre=True)
-    @classmethod
-    def set_bsse_type(cls, v: Any) -> List[BsseEnum]:
-        if not isinstance(v, list):
-            v = [v]
-        # emulate ordered set
-        # * bt.lower() as return (w/i `list(dict.fromkeys([bt.lower() ...`)
-        #   works until aliases added to BsseEnum
-        # * BsseEnum[bt].value as return works for good vals, but passing bad
-        #   vals through as bt lets pydantic raise a clearer error message
-        return list(dict.fromkeys([(BsseEnum[bt.lower()].value if bt.lower() in BsseEnum.__members__ else bt.lower()) for bt in v]))
-
-
-class ManyBodySpecification(ProtoModel):
-
-    schema_name: Literal["qcschema_manybodyspecification"] = "qcschema_manybodyspecification"
-    #provenance: Provenance = Field(Provenance(**provenance_stamp(__name__)), description=Provenance.__doc__)
-    keywords: ManyBodyKeywords = Field(..., description=ManyBodyKeywords.__doc__)
-    #program: str = Field(..., description="The program for which the Specification is intended.")
-    driver: DriverEnum = Field(
-        ...,
-        description="The computation driver; i.e., energy, gradient, hessian.",
-    )
-    #specification: Union[AtomicSpecification, Dict[str, AtomicSpecification]] = Field(
-    specification: Dict[str, AtomicSpecification] = Field(
-        ...,
-        description="??? TODO expand to cbs, fd",
-    )
-
-    # v2: @field_validator("specification", mode="before")
-    @validator("specification", pre=True)
-    @classmethod
-    def set_specification(cls, v: Any) -> Dict[str, AtomicSpecification]:
-        #print(f"hit atomicspecification validator with {type(v)=} {v}", end="")
-        # v could be model instance or dict
-        if isinstance(v, AtomicSpecification) or "model" in v:
-            v = {"(auto)": v}
-        #print(f" ... setting v={v}")
-        return v
-
-
-class ManyBodyInput(ProtoModel):
-
-    schema_name: Literal["qcschema_manybodyinput"] = "qcschema_manybodyinput"
-    #provenance: Provenance = Field(Provenance(**provenance_stamp(__name__)), description=Provenance.__doc__)
-    specification: ManyBodySpecification = Field(
-        ...,
-        description="???",
-    )
-    molecule: Molecule = Field(
-        ...,
-        description="Target molecule for many-body expansion (MBE) or interaction energy (IE) analysis.",
-    )
-    #protocols
-
-
-# ====  Protocols  ==============================================================
-
-class ManyBodyProtocolEnum(str, Enum):
-    """
-    Which atomic evaluations to keep in a many body evaluation.
-    """
-
-    all = "all"
-    all_real = "all_real"
-    largest_body = "largest_body"
-    none = "none"
-
-
-class ManyBodyProtocols(ProtoModel):
-    """
-    Protocols regarding the manipulation of a ManyBody output data.
-    """
-
-    atomics: ManyBodyProtocolEnum = Field(
-        ManyBodyProtocolEnum.all,
-        description=str(ManyBodyProtocolEnum.__doc__),
-    )
-
-    # v2: model_config = ExtendedConfigDict(force_skip_defaults=True)
-    class Config:
-        force_skip_defaults = True
+from .manybody_input_pydv1 import ManyBodyInput, SuccessfulResultBase
 
 
 # ====  Properties  =============================================================
@@ -501,7 +280,7 @@ class ProtoModelSkipDefaults(ProtoModel):
 if TYPE_CHECKING:
     ManyBodyResultProperties = ProtoModelSkipDefaults
 else:
-    # if/else suppresses a warning about using dynamically generated class as Field type in ManyBodyResults
+    # if/else suppresses a warning about using a dynamically generated class as Field type in ManyBodyResults
     ManyBodyResultProperties = create_model(
     "ManyBodyResultProperties",
     #__doc__=manybodyresultproperties_doc,  # needs later pydantic

--- a/qcmanybody/qcng_computer.py
+++ b/qcmanybody/qcng_computer.py
@@ -11,7 +11,7 @@ nppp10 = partial(np.array_str, max_line_width=120, precision=10, suppress_small=
 
 from ast import literal_eval
 # v2: from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Tuple, Union, Literal, Optional
-from typing import Any, Dict, List, Mapping, Tuple, Union, Literal, Optional
+from typing import Any, Dict, List, Mapping, Tuple, Union, Literal, Optional, TYPE_CHECKING
 
 # v2: from pydantic import ConfigDict, field_validator, FieldValidationInfo, computed_field, BaseModel, Field
 try:
@@ -24,6 +24,9 @@ import qcengine as qcng
 from qcmanybody import ManyBodyCalculator
 from qcmanybody.utils import delabeler, provenance_stamp
 from qcmanybody.models import BsseEnum, ManyBodyKeywords, ManyBodyInput, ManyBodyResult, ManyBodyResultProperties
+
+if TYPE_CHECKING:
+    import qcportal
 
 
 class BaseComputerQCNG(ProtoModel):

--- a/qcmanybody/qcng_computer.py
+++ b/qcmanybody/qcng_computer.py
@@ -259,16 +259,6 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
             # rearrange bodies in order with supersystem last lest body count fail in organization loop below
             v = dict(sorted(v.items(), key=lambda item: 1000 if item[0] == "supersystem" else item[0]))
 
-            # rm 1 for cp-only
-            # We define cp as being a correction to only interaction energies
-            # If only doing cp, we need to ignore any user-specified 1st (monomer) level
-            #if 'cp' in kwargs.get("bsse_type", None) and 'nocp' not in kwargs.get("bsse_type", None):
-            #    if 1 in levels.keys():
-            #        removed_level = levels.pop(1)
-            #        logger.info("NOTE: User specified exclusively 'cp' correction, but provided level 1 details")
-            #        logger.info(f"NOTE: Removing level {removed_level}")
-            #        logger.info("NOTE: For total energies, add 'nocp' to bsse_list")
-
         print(f" ... setting levels={v}")
         return v
 
@@ -371,7 +361,7 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
         return sio
 
     @classmethod
-    def from_qcschema_ben(cls, input_model: ManyBodyInput, build_tasks: bool = True):
+    def from_manybodyinput(cls, input_model: ManyBodyInput, build_tasks: bool = True):
 
         computer_model = cls(
             molecule=input_model.molecule,
@@ -413,7 +403,7 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
         )
 
         if not build_tasks:
-            return calculator_cls
+            return computer_model, calculator_cls
 
         component_results = {}
 
@@ -430,7 +420,7 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
                     raise RuntimeError(f"Don't know how to handle external charges in {specifications[chem]['program']}")
 
             _, real, bas = delabeler(label)
-            result = qcng.compute(inp, specifications[chem]["program"], task_config={"memory": 2})
+            result = qcng.compute(inp, specifications[chem]["program"])
 
             if not result.success:
                 print(result.error.error_message)
@@ -459,142 +449,6 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
 
         return computer_model.get_results(external_results=analyze_back)
 
-    @classmethod
-    def from_qcschema(cls, input_model: ManyBodyInput, build_tasks: bool = False):
-
-        computer_model = cls(
-            molecule=input_model.molecule,
-            driver=input_model.specification.driver,
-            # v2: **input_model.specification.keywords.model_dump(exclude_unset=True),
-            **input_model.specification.keywords.dict(exclude_unset=True),
-            input_data=input_model,  # storage, to reconstitute ManyBodyResult
-        )
-
-        print("\n<<<  (Z) QCEngine harness ManyBodyComputerQCNG.from_qcschema  >>>")
-        # v2: pprint.pprint(computer_model.model_dump(), width=200)
-        pprint.pprint(computer_model.dict(), width=200)
-
-        if build_tasks:
-            # Note: self.input_data or input input_model.
-            #   Also, we've always tried to keep build_tasks separate (see psi4.driver.task_planner).
-            #   Clearly one _can_ init from ManyBodyInput -- make this sep fn?
-
-            for mc_level_idx, mtd in enumerate(computer_model.levels.values()):
-                atspec = computer_model.input_data.specification.specification[mtd]
-
-                computer_model.build_tasks(
-                    AtomicComputerQCNG,
-                    mc_level_idx=mc_level_idx,
-                    program=atspec.program,
-                    driver=atspec.driver,  # use manybodyspecification.driver instead?
-                    method=atspec.model.method,
-                    basis=atspec.model.basis,
-                    keywords=atspec.keywords,
-                    #protocols=atspec.protocols,
-                    #**kwargs,
-                )
-
-        return computer_model
-
-    def build_tasks(
-        self,
-        mb_computer: AtomicComputerQCNG, #MBETaskComputers,
-        mc_level_idx: int,
-        **kwargs: Dict[str, Any],
-    ) -> int:
-        """Adds to the task_list as many new unique tasks as necessary to treat a single model chemistry level at one
-        or several n-body levels. New tasks are of type *mb_computer* with model chemistry level specified in *kwargs*
-        and n-body levels accessed through *mc_level_idx*.
-
-        Parameters
-        ----------
-#        mb_computer
-#            Class of task computers to instantiate and add to self.task_list. Usually :class:`~psi4.driver.AtomicComputer` but may be other when wrappers are layered.
-#        mc_level_idx
-#            Position in field self.nbodies_per_mc_level used to obtain ``nbodies``, the list of n-body
-#            levels (e.g., `[1]` or `[1, 2]` or `["supersystem"]`) to which the modelchem specified in **kwargs** applies.
-#            That is, `nbodies = self.nbodies_per_mc_level[mc_level_idx]`.
-#            Note the natural 1-indexing of ``nbodies`` _contents_, so `[1]` covers one-body contributions.
-#            The corresponding user label is the 1-indexed counterpart, `mc_level_lbl = mc_level_idx + 1`
-#            Formerly nlevel as in `nbody = self.nbody_list[nbody_level=nlevel]`.
-#        kwargs
-#            Other arguments for initializing **mb_computer**. In particular, specifies model chemistry.
-
-        Returns
-        -------
-        count : int
-            Number of new tasks planned by this call.
-            Formerly, didn't include supersystem in count.
-
-        """
-# qcng:        from psi4.driver.driver_nbody import build_nbody_compute_list
-
-        # TODO method not coming from levels right
-
-        # Get the n-body orders for this level. e.g., [1] or [2, 3] or ["supersystem"]
-        nbodies = self.nbodies_per_mc_level[mc_level_idx]
-
-#        info = "\n" + p4util.banner(f" ManyBody Setup: N-Body Levels {nbodies}", strNotOutfile=True) + "\n"
-#        core.print_out(info)
-#        logger.info(info)
-
-#        for kwg in ['dft_functional']:
-#            if kwg in kwargs:
-#                kwargs['keywords']['function_kwargs'][kwg] = kwargs.pop(kwg)
-
-        count = 0
-        template = copy.deepcopy(kwargs)
-
-        # Get compute list
-        if nbodies == ["supersystem"]:
-            # Add supersystem computation if requested -- always nocp
-            data = template
-            data["molecule"] = self.molecule
-            key = f"supersystem_{self.nfragments}"
-            self.task_list[key] = mb_computer(**data)
-            count += 1
-
-            compute_dict = build_nbody_compute_list(
-                ["nocp"], list(range(1, self.max_nbody + 1)),
-                self.nfragments, self.return_total_data, self.supersystem_ie_only)
-        else:
-            compute_dict = build_nbody_compute_list(
-                self.bsse_type, nbodies,
-                self.nfragments, self.return_total_data, self.supersystem_ie_only)
-
-        def lab_labeler(item) -> str:
-            # note 0-index to 1-index shift for label
-            return f"{mc_level_idx + 1}_{item}"
-
-        print("HHHH", compute_dict)
-        # Add current compute list to the master task list
-        # * `pair` looks like `((1,), (1, 3))` where first is real (not ghost) fragment indices
-        #    and second is basis set fragment indices, all 1-indexed
-        for nb in compute_dict["all"]:
-            for pair in compute_dict["all"][nb]:
-                lbl = lab_labeler(pair)
-                if lbl in self.task_list:
-                    continue
-
-                data = template
-                ghost = list(set(pair[1]) - set(pair[0]))
-                # while psi4.core.Molecule.extract_subsets takes 1-indexed, qcel.models.Molecule.get_fragment takes 0-indexed.
-                real0 = [(idx - 1) for idx in list(pair[0])]
-                ghost0 = [(idx - 1) for idx in ghost]
-                data["molecule"] = self.molecule.get_fragment(real=real0, ghost=ghost0, group_fragments=False)  # orient?
-#                if self.embedding_charges:
-#                    embedding_frags = list(set(range(1, self.nfragments + 1)) - set(pair[1]))
-#                    charges = []
-#                    for frag in embedding_frags:
-#                        positions = self.molecule.extract_subsets(frag).geometry().np.tolist()
-#                        charges.extend([[chg, i] for i, chg in zip(positions, self.embedding_charges[frag])])
-#                    data['keywords']['function_kwargs'].update({'external_potentials': charges})
-
-                self.task_list[lbl] = mb_computer(**data)
-                count += 1
-
-        return count
-
     def plan(self):
         # uncalled function
         return [t.plan() for t in self.task_list.values()]
@@ -612,153 +466,15 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
         for t in self.task_list.values():
             t.compute(client=client)
 
-    def prepare_results(
-        self,
-        results: Optional[Dict[str, "MBETaskComputers"]] = None,
-        client: Optional["qcportal.FractalClient"] = None,
-    ) -> Dict[str, Any]:
-        """Process the results from all n-body component molecular systems and model chemistry levels into final quantities.
+    def get_results(self, external_results: Dict, client: Optional["qcportal.FractalClient"] = None) -> ManyBodyResult:
+        """Return results as ManyBody-flavored QCSchema."""
 
-        NOTE: client removed (compared to psi4.driver.ManyBodyComputer) (multilevel call, too)
-
-#        Parameters
-#        ----------
-#        results
-#            A set of tasks to process instead of self.task_list. Used in multilevel processing to pass a subset of
-#            self.task_list filtered to only one modelchem level.
-#        client
-#            QCFractal client if using QCArchive for distributed compute.
-#
-#        Returns
-#        -------
-#        nbody_results
-#            When the ManyBodyComputer specifies a single model chemistry level (see self.nbodies_per_mc_level), the
-#            return is a dictionary, nbody_results, described in the table below. Many of the items are actually filled
-#            by successive calls to assemble_nbody_components(). When multiple model chemistry levels are specified, this
-#            function diverts its return to driver_nbody_multilevel.prepare_results() wherein each mc level calls this
-#            function again and collects separate nbody_results dictionaries and processes them into a final return that
-#            is a small subset of the table below.
-#
-#
-#                                       ptype_size = (1,)/(nat, 3)/(3 * nat, 3 * nat)
-#                                        e/g/h := energy or gradient or Hessian
-#                                        rtd := return_total_data
-#
-        """
-# qcng:        from psi4.driver.driver_nbody import assemble_nbody_components
-# qcng:        from psi4.driver.driver_nbody_multilevel import prepare_results as multilevel_prepare_results
-
-        if results is None:
-            print(f"RESULTS setting empty")
-            results = {}
-
-#        # formerly nlevels
-        mc_level_labels = {i.split("_")[0] for i in self.task_list}
-        print("RESULTS", mc_level_labels, len(results), results.keys())
-        if len(mc_level_labels) > 1 and not results:  # seeming fix to recursion
-#        if len(self.nbodies_per_mc_level) > 1 and not results:  # max recursion
-            print(f"RESULTS calling MLVL")
-            return multilevel_prepare_results(self, client=client)
-
-        results_list = {k: v.get_results(client=client) for k, v in (results.items() or self.task_list.items())}
-
-#        pp.pprint(results_list["1_((1, 2), (1, 2))"].model_dump())
-        #if "1_((1, 2, 3, 4), (1, 2, 3, 4))" in results_list:
-        #    pp.pprint(results_list["1_((1, 2, 3, 4), (1, 2, 3, 4))"].model_dump())
-        if "1_((3,), (3,))" in results_list:
-            # v2: pp.pprint(results_list["1_((3,), (3,))"].model_dump())
-            pp.pprint(results_list["1_((3,), (3,))"].dict())
-        trove = {  # AtomicResult.properties return None if missing
-            "energy": {k: v.properties.return_energy for k, v in results_list.items()},
-            "gradient": {k: v.properties.return_gradient for k, v in results_list.items()},
-            "hessian": {k: v.properties.return_hessian for k, v in results_list.items()},
-        }
-
-#        # TODO: make assemble_nbody_components and driver_nbody_multilevel.prepare_results into class functions.
-#        #   note that the former uses metadata as read-only (except for one solveable case) while the latter overwrites self (!).
-        metadata = {
-            "quiet": False, #self.quiet,
-            "nbodies_per_mc_level": self.nbodies_per_mc_level,
-            "bsse_type": self.bsse_type,
-            "nfragments": self.nfragments,
-            "return_total_data": self.return_total_data,
-            "supersystem_ie_only": self.supersystem_ie_only,
-            "molecule": self.molecule,
-            "embedding_charges": bool(self.embedding_charges),
-            "max_nbody": self.max_nbody,
-        }
-        if self.driver.name == "energy":
-            nbody_results = assemble_nbody_components("energy", trove["energy"], metadata.copy())
-
-        elif self.driver.name == "gradient":
-            nbody_results = assemble_nbody_components("energy", trove["energy"], metadata.copy())
-            nbody_results.update(assemble_nbody_components("gradient", trove["gradient"], metadata.copy()))
-
-        elif self.driver.name == "hessian":
-            nbody_results = assemble_nbody_components("energy", trove["energy"], metadata.copy())
-            nbody_results.update(assemble_nbody_components("gradient", trove["gradient"], metadata.copy()))
-            nbody_results.update(assemble_nbody_components("hessian", trove["hessian"], metadata.copy()))
-
-        # save some mc_(frag, bas) component results
-        # * formerly, intermediates_energy was intermediates2
-        # * formerly, intermediates_gradient was intermediates_ptype
-        # * formerly, intermediates_hessian was intermediates_ptype
-
-        nbody_results["intermediates"] = {}
-        for idx, task in results_list.items():
-            mc, frag, bas = lab_delabeler(idx)
-            nbody_results["intermediates"][f"N-BODY ({frag})@({bas}) TOTAL ENERGY"] = task.properties.return_energy
-
-        nbody_results["intermediates_energy"] = trove["energy"]
-
-        if not all(x is None for x in trove["gradient"].values()):
-            nbody_results["intermediates_gradient"] = trove["gradient"]
-
-        if not all(x is None for x in trove["hessian"].values()):
-            nbody_results["intermediates_hessian"] = trove["hessian"]
-
-#        debug = False
-#        if debug:
-#            for k, v in nbody_results.items():
-#                if isinstance(v, np.ndarray):
-#                    print(f"CLS-prepared results >>> {k} {v.size}")
-#                elif isinstance(v, dict):
-#                    print(f"CLS-prepared results >>> {k} {len(v)}")
-#                    for k2, v2 in v.items():
-#                        if isinstance(v2, np.ndarray):
-#                            print(f"CLS-prepared results      >>> {k2} {v2.size}")
-#                        else:
-#                            print(f"CLS-prepared results      >>> {k2} {v2}")
-#                else:
-#                    print(f"CLS-prepared results >>> {k} {v}")
-
-        return nbody_results
-
-
-    def get_results(self, client: Optional["qcportal.FractalClient"] = None, external_results: Optional[Dict] = None) -> ManyBodyResult:
-        """Return results as ManyBody-flavored QCSchema.
-
-        NOTE: client removed (compared to psi4.driver.ManyBodyComputer)
-        """
-# qcng:        from psi4.driver.p4util import banner
-
-# qcng:        info = "\n" + banner(f" ManyBody Results ", strNotOutfile=True) + "\n"
-        #logger.info(info)
-
-        if external_results is None:
-            results = self.prepare_results(client=client)
-            ret_energy = results.pop("ret_energy")
-            ret_ptype = results.pop("ret_ptype")
-            ret_gradient = results.pop("ret_gradient", None)
-            nbody_number = len(self.task_list)
-        else:
-            ret_energy = external_results.pop("ret_energy")
-            ret_ptype = ret_energy if self.driver == "energy" else external_results.pop(f"ret_{self.driver.name}")
-            ret_gradient = external_results.pop("ret_gradient", None)
-            nbody_number = external_results.pop("nbody_number")
-            component_properties = external_results.pop("component_properties")
-            stdout = external_results.pop("stdout")
-
+        ret_energy = external_results.pop("ret_energy")
+        ret_ptype = ret_energy if self.driver == "energy" else external_results.pop(f"ret_{self.driver.name}")
+        ret_gradient = external_results.pop("ret_gradient", None)
+        nbody_number = external_results.pop("nbody_number")
+        component_properties = external_results.pop("component_properties")
+        stdout = external_results.pop("stdout")
 
         # load QCVariables
         qcvars = {
@@ -775,14 +491,10 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
             "return_energy": ret_energy,
         }
 
-        if external_results is None:
-            for k, val in results.items():
-                qcvars[k] = val
-        else:
-            for k, val in external_results.items():
-                if k == "results":
-                    k = "nbody"
-                qcvars[k] = val
+        for k, val in external_results.items():
+            if k == "results":
+                k = "nbody"
+            qcvars[k] = val
 
         qcvars['CURRENT ENERGY'] = ret_energy
         if self.driver == 'gradient':

--- a/qcmanybody/qcng_computer.py
+++ b/qcmanybody/qcng_computer.py
@@ -21,9 +21,9 @@ except ImportError:
 
 from qcelemental.models import FailedOperation, Molecule, DriverEnum, ProtoModel, AtomicResult, AtomicInput
 import qcengine as qcng
-from .manybody_pydv1 import BsseEnum, ManyBodyKeywords, ManyBodyInput, ManyBodyResult, ManyBodyResultProperties
 from qcmanybody import ManyBodyCalculator
 from qcmanybody.utils import delabeler, provenance_stamp
+from qcmanybody.models import BsseEnum, ManyBodyKeywords, ManyBodyInput, ManyBodyResult, ManyBodyResultProperties
 
 
 class BaseComputerQCNG(ProtoModel):
@@ -430,7 +430,7 @@ class ManyBodyComputerQCNG(BaseComputerQCNG):
                     raise RuntimeError(f"Don't know how to handle external charges in {specifications[chem]['program']}")
 
             _, real, bas = delabeler(label)
-            result = qcng.compute(inp, specifications[chem]["program"])
+            result = qcng.compute(inp, specifications[chem]["program"], task_config={"memory": 2})
 
             if not result.success:
                 print(result.error.error_message)

--- a/qcmanybody/tests/test_mbe_he4_multilevel.py
+++ b/qcmanybody/tests/test_mbe_he4_multilevel.py
@@ -726,7 +726,7 @@ def test_nbody_he4_multi(levels, mbe_keywords, anskey, bodykeys, outstrs, calcin
     mbe_model = ManyBodyInput(**mbe_data_multilevel_631g)
 
     # qcng: ret = qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
-    ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
+    ret = ManyBodyComputerQCNG.from_manybodyinput(mbe_model)
     print(f"MMMMMMM {request.node.name}")
     pprint.pprint(ret.dict(), width=200)
 
@@ -896,7 +896,7 @@ def test_count_he4_multi(mbe_keywords, ref_count, he_tetramer, request):
     atomic_spec = AtomicSpecification(model={"method": "mp2", "basis": "mybas"}, program="myqc", driver="energy")
     mbe_model = ManyBodyInput(specification={"specification": atomic_spec, "keywords": mbe_keywords, "driver": "energy"}, molecule=he_tetramer)
 
-    ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model, build_tasks=False)
+    _, ret = ManyBodyComputerQCNG.from_manybodyinput(mbe_model, build_tasks=False)
 
     text, dcount = ret.format_calc_plan()
     assert compare_recursive(ref_count["all"], dcount, atol=1.e-6)

--- a/qcmanybody/tests/test_mbe_he4_multilevel.py
+++ b/qcmanybody/tests/test_mbe_he4_multilevel.py
@@ -9,8 +9,8 @@ from qcelemental.models import Molecule
 # v2: from qcelemental.models.procedures_manybody import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
 from qcelemental.testing import compare_values, compare_recursive
 
-from qcmanybody.models.manybody_pydv1 import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
-from qcmanybody.models.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
+from qcmanybody.models import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
+from qcmanybody.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
 
 import qcengine as qcng
 from .addons import using

--- a/qcmanybody/tests/test_mbe_he4_multilevel.py
+++ b/qcmanybody/tests/test_mbe_he4_multilevel.py
@@ -819,7 +819,7 @@ def test_nbody_he4_supersys(levels, mbe_keywords, anskey, bodykeys, outstrs, cal
     mbe_model = ManyBodyInput(**mbe_data_multilevel_631g)
 
     # qcng: ret = qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
-    ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
+    ret = ManyBodyComputerQCNG.from_manybodyinput(mbe_model)
     print(f"MMMMMMM {request.node.name}")
     pprint.pprint(ret.dict(), width=200)
 

--- a/qcmanybody/tests/test_mbe_he4_singlelevel.py
+++ b/qcmanybody/tests/test_mbe_he4_singlelevel.py
@@ -625,7 +625,7 @@ def test_nbody_he4_single(program, basis, keywords, mbe_keywords, anskey, bodyke
     mbe_model = ManyBodyInput(specification={"specification": atomic_spec, "keywords": mbe_keywords, "driver": "energy"}, molecule=he_tetramer)
 
     # qcng: ret = qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
-    ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
+    ret = ManyBodyComputerQCNG.from_manybodyinput(mbe_model)
     print(f"SSSSSSS {request.node.name}")
     # v2: pprint.pprint(ret.model_dump(), width=200)
     pprint.pprint(ret.dict(), width=200)
@@ -708,7 +708,7 @@ def test_count_he4_single(mbe_keywords, ref_count, he_tetramer):
     atomic_spec = AtomicSpecification(model={"method": "mp2", "basis": "mybas"}, program="myqc", driver="energy")
     mbe_model = ManyBodyInput(specification={"specification": atomic_spec, "keywords": mbe_keywords, "driver": "energy"}, molecule=he_tetramer)
 
-    ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model, build_tasks=False)
+    _, ret = ManyBodyComputerQCNG.from_manybodyinput(mbe_model, build_tasks=False)
 
     text, dcount = ret.format_calc_plan()
     assert compare_recursive(ref_count["all"], dcount, atol=1.e-6)

--- a/qcmanybody/tests/test_mbe_he4_singlelevel.py
+++ b/qcmanybody/tests/test_mbe_he4_singlelevel.py
@@ -8,8 +8,8 @@ from qcelemental.models import Molecule
 # v2: from qcelemental.models.procedures_manybody import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
 from qcelemental.testing import compare_values, compare_recursive
 
-from qcmanybody.models.manybody_pydv1 import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
-from qcmanybody.models.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
+from qcmanybody.models import AtomicSpecification, ManyBodyKeywords, ManyBodyInput
+from qcmanybody.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
 
 import qcengine as qcng
 from .addons import using

--- a/qcmanybody/tests/test_mbe_het4_grad.py
+++ b/qcmanybody/tests/test_mbe_het4_grad.py
@@ -7,8 +7,8 @@ import numpy as np
 from qcelemental.models import Molecule
 from qcelemental.testing import compare_values
 
-from qcmanybody.models.manybody_pydv1 import ManyBodyKeywords, ManyBodyInput
-from qcmanybody.models.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
+from qcmanybody.models import ManyBodyKeywords, ManyBodyInput
+from qcmanybody.qcng_computer import ManyBodyComputerQCNG, qcvars_to_manybodyproperties
 
 from .addons import uusing
 

--- a/qcmanybody/tests/test_mbe_het4_grad.py
+++ b/qcmanybody/tests/test_mbe_het4_grad.py
@@ -258,7 +258,7 @@ def test_nbody_het4_grad(mbe_keywords, anskeyE, anskeyG, bodykeys, outstrs, calc
     mbe_model = ManyBodyInput(**mbe_data_grad_dtz)
 
     # qcng: ret = qcng.compute_procedure(mbe_model, "manybody", raise_error=True)
-    ret = ManyBodyComputerQCNG.from_qcschema_ben(mbe_model)
+    ret = ManyBodyComputerQCNG.from_manybodyinput(mbe_model)
     print(f"MMMMMMM {request.node.name}")
     pprint.pprint(ret.dict(), width=200)
 

--- a/qcmanybody/tests/test_mbe_keywords.py
+++ b/qcmanybody/tests/test_mbe_keywords.py
@@ -103,7 +103,7 @@ def test_mbe_rtd(mbe_data, driver, kws, ans):
     mbe_data["specification"]["keywords"] = kws
 
     input_model = ManyBodyInput(**mbe_data)
-    comp_model = ManyBodyComputerQCNG.from_qcschema(input_model)
+    comp_model, _ = ManyBodyComputerQCNG.from_manybodyinput(input_model, build_tasks=False)
 
     assert comp_model.driver == driver
     assert comp_model.return_total_data == ans
@@ -150,7 +150,7 @@ def test_mbe_level_bodies(mbe_data, kws, ans):
     mbe_data["specification"]["keywords"] = kws
 
     input_model = ManyBodyInput(**mbe_data)
-    comp_model = ManyBodyComputerQCNG.from_qcschema(input_model)
+    comp_model, _ = ManyBodyComputerQCNG.from_manybodyinput(input_model, build_tasks=False)
 
     assert comp_model.nfragments == 3
     assert comp_model.max_nbody == ans[0]
@@ -178,7 +178,7 @@ def test_mbe_level_5mer(mbe_data, kws, ans):
     mbe_data["specification"]["keywords"] = kws
 
     input_model = ManyBodyInput(**mbe_data)
-    comp_model = ManyBodyComputerQCNG.from_qcschema(input_model)
+    comp_model, _ = ManyBodyComputerQCNG.from_manybodyinput(input_model, build_tasks=False)
 
     assert comp_model.nfragments == 5
     assert comp_model.max_nbody == ans[0]
@@ -200,7 +200,7 @@ def test_mbe_level_fails(mbe_data, kws, errmsg):
     # v2: with pytest.raises(Exception):
     with pytest.raises(ValidationError) as e:
         input_model = ManyBodyInput(**mbe_data)
-        ManyBodyComputerQCNG.from_qcschema(input_model)
+        ManyBodyComputerQCNG.from_manybodyinput(input_model, build_tasks=False)
 
     assert errmsg in str(e.value), e.value
 
@@ -228,9 +228,9 @@ def test_mbe_bsse_type(mbe_data, kws, ans):
         return
 
     input_model = ManyBodyInput(**mbe_data)
-    comp_model = ManyBodyComputerQCNG.from_qcschema(input_model)
+    comp_model, _ = ManyBodyComputerQCNG.from_manybodyinput(input_model, build_tasks=False)
 
-    assert comp_model.bsse_type == ans
+    assert comp_model.bsse_type == ans, f"{comp_model=} != {ans}"
 
 
 @pytest.mark.parametrize("kws,ans", [
@@ -250,13 +250,13 @@ def test_mbe_sie(mbe_data, kws, ans):
     if isinstance(ans, str):
         input_model = ManyBodyInput(**mbe_data)
         with pytest.raises(ValidationError) as e:
-            comp_model = ManyBodyComputerQCNG.from_qcschema(input_model)
+            ManyBodyComputerQCNG.from_manybodyinput(input_model, build_tasks=False)
 
         assert ans in str(e.value)
         return
 
     input_model = ManyBodyInput(**mbe_data)
-    comp_model = ManyBodyComputerQCNG.from_qcschema(input_model)
+    comp_model, _ = ManyBodyComputerQCNG.from_manybodyinput(input_model, build_tasks=False)
 
     assert comp_model.supersystem_ie_only == ans
 

--- a/qcmanybody/tests/test_mbe_keywords.py
+++ b/qcmanybody/tests/test_mbe_keywords.py
@@ -10,12 +10,12 @@ except ImportError:
 
 import qcelemental
 from qcelemental.models import DriverEnum, Molecule
-from qcmanybody.models.manybody_pydv1 import BsseEnum, ManyBodyInput
+from qcmanybody.models import BsseEnum, ManyBodyInput
 
 import qcengine as qcng
 
 # qcng: from qcengine.procedures.manybody import ManyBodyComputerQCNG
-from qcmanybody.models.qcng_computer import ManyBodyComputerQCNG
+from qcmanybody.qcng_computer import ManyBodyComputerQCNG
 from qcmanybody import ManyBodyCalculator
 
 


### PR DESCRIPTION
- [x] split schema into input and output files in anticipation of longer input validation
- [x] move qcng_computer to main dir
- [x] remove long unused fns from above
- [x] rename `from_qcschema_ben` to `from_manybodyinput`. kill off `from_qcschema`