### PR TITLE
precise math

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,29 @@
 -->
 
 
+## v0.4.0 / 2024-MM-DD (Unreleased)
+
+#### Breaking Changes
+ * [\#36](https://github.com/MolSSI/QCManyBody/pull/36) Feature -- as the embedded point charges aren't fully validated
+   and (in the QCEngine computer function of the high-level interface) only work with Psi4 anyways, they are now hidden.
+   Set environment variable `QCMANYBODY_EMBEDDING_CHARGES=1` to access functionality. @loriab
+
+#### New Features
+
+#### Enhancements
+ * [\#36](https://github.com/MolSSI/QCManyBody/pull/36) Utils -- when adding up results from many molecular species,
+   now the compensated sums `math.fsum` or `numpy.sum` are used.
+
+#### Bug Fixes
+
+#### Misc.
+
+#### MUST (Unmerged)
+
+#### WIP (Unmerged)
+
+
+
 ## v0.3.0 / 2024-07-21
 
 #### Breaking Changes

--- a/qcmanybody/core.py
+++ b/qcmanybody/core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import string
 from collections import Counter, defaultdict
 from typing import Any, Dict, Iterable, Literal, Mapping, Sequence, Set, Tuple, Union
@@ -44,6 +45,12 @@ class ManyBodyCore:
         embedding_charges: Mapping[int, Sequence[float]],
     ):
         self.embedding_charges = embedding_charges
+        if self.embedding_charges:
+            if not bool(os.environ.get("QCMANYBODY_EMBEDDING_CHARGES", False)):  # obscure until further validation
+                raise ValueError(
+                    f"Embedding charges for EE-MBE are still in testing. Set environment variable QCMANYBODY_EMBEDDING_CHARGES=1 to use at your own risk."
+                )
+
         if isinstance(molecule, dict):
             mol = Molecule(**molecule)
         elif isinstance(molecule, Molecule):

--- a/qcmanybody/models/manybody_input_pydv1.py
+++ b/qcmanybody/models/manybody_input_pydv1.py
@@ -140,7 +140,9 @@ class ManyBodyKeywords(ProtoModel):
     embedding_charges: Optional[Dict[int, List[float]]] = Field(
         None,
         description="Atom-centered point charges to be used on molecule fragments whose basis sets are not included in "
-        "the computation. Keys: 1-based index of fragment. Values: list of atom charges for that fragment.",
+        "the computation. Keys: 1-based index of fragment. Values: list of atom charges for that fragment. "
+        "At present, QCManyBody will only accept non-None values of this keyword if environment variable "
+        "QCMANYBODY_EMBEDDING_CHARGES is set.",
         # TODO embedding charges should sum to fragment charge, right? enforce?
         # TODO embedding charges irrelevant to CP (basis sets always present)?
         json_schema_extra={

--- a/qcmanybody/models/manybody_output_pydv1.py
+++ b/qcmanybody/models/manybody_output_pydv1.py
@@ -33,7 +33,6 @@ manybodyresultproperties_doc = """
 
 MAX_NBODY = int(os.environ.get("QCMANYBODY_MAX_NBODY", 5))  # 5 covers tetramers
 
-# TODO: bump up default MAX_NBODY and add some warnings or mitigations so insufficient value doesn't fail at very end at Result formation time
 
 json_schema_extras = {
     "energy": {"units": "E_h"},

--- a/qcmanybody/tests/test_computer_het4_gradient.py
+++ b/qcmanybody/tests/test_computer_het4_gradient.py
@@ -243,11 +243,10 @@ def het_tetramer():
         15,
         id="4b_nocp_rtd_ee"),
 ])
-def test_nbody_het4_grad(mbe_keywords, anskeyE, anskeyG, bodykeys, outstrs, calcinfo_nmbe, het_tetramer, request, mbe_data_grad_dtz):
+def test_nbody_het4_grad(mbe_keywords, anskeyE, anskeyG, bodykeys, outstrs, calcinfo_nmbe, het_tetramer, request, mbe_data_grad_dtz, monkeypatch):
     _inner = request.node.name.split("[")[1].split("]")[0]
     kwdsln, pattern, progln = _inner, "", "psi4"
-    print("LANE", kwdsln, pattern, progln)
-    os.environ["QCMANYBODY_EMBEDDING_CHARGES"] = "1"
+    monkeypatch.setenv("QCMANYBODY_EMBEDDING_CHARGES", "1")
 
     mbe_keywords = ManyBodyKeywords(**mbe_keywords)
     mbe_data_grad_dtz["molecule"] = het_tetramer

--- a/qcmanybody/utils.py
+++ b/qcmanybody/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import json
+import math
 import re
 import string
 from typing import Any, Dict, Iterable, List, Literal, Mapping, Optional, Set, Tuple, Union
@@ -222,13 +223,22 @@ def sum_cluster_data(
     shape = find_shape(data[first_key])
     ret = shaped_zero(shape)
 
-    for frag, bas in compute_list:
-        egh = data[labeler(mc_level_lbl, frag, bas)]
+    precise_sum_func = math.fsum if isinstance(ret, float) else np.sum
+    ret = precise_sum_func(
+        (((-1) ** (nb - len(frag))) if vmfc else 1) * (data[labeler(mc_level_lbl, frag, bas)])
+        for frag, bas in compute_list
+    )
 
-        if vmfc:
-            sign = (-1) ** (nb - len(frag))
-
-        ret += sign * egh
+    # A more readable format for the above but not ammenable to using specialty summation functions
+    # ```
+    # for frag, bas in compute_list:
+    #     egh = data[labeler(mc_level_lbl, frag, bas)]
+    #
+    #     if vmfc:
+    #         sign = (-1) ** (nb - len(frag))
+    #
+    #     ret += sign * egh
+    # ```
 
     return ret
 


### PR DESCRIPTION
- [x] point charge handling (only worked for psi4) disabled in core interface unless envvar `QCMANYBODY_EMBEDDING_CHARGES=1`
- [x] use `math.fsum` or `numpy.sum` for sum-over-molecular-subsystems