### PR TITLE
Counterpart to QCEl rc4

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,27 @@ Changelog
 
 :docs:`dev` for latest.
 
+.. _`sec:cl070`:
+
+v0.7.0 / 2026-03-27
+===================
+
+:docs:`v0.7.0` for current. :docs:`v0.5.2` for QCSchema v1.
+
+Breaking Changes
+----------------
+* :pr:`47` Models -- All models now serialize to containing ``schema_name`` field.
+  ``ManyBodyProperties`` also includes schema_name, but not all the Nones.
+
+Enhancements
+------------
+* :pr:`47` Schema -- Compatibility with https://github.com/MolSSI/QCElemental/pull/393
+  (QCElemental 0.50.0rc4) that replaces early QCElemental routines with native
+  Pydantic serialization.
+* :pr:`47` Models -- Add ``QCManyBody.models.v1.ManyBodyResultProperties.convert_v()``
+  and ``QCManyBody.models.v2.ManyBodyProperties.convert_v()`` to interconvert.
+
+
 .. _`sec:cl061`:
 
 v0.6.1 / 2026-03-11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,13 @@ dependencies = [
     "numpy",
     "pydantic >=2.11; python_version <'3.14'",
     "pydantic >=2.12; python_version >='3.14'",
-    "qcelemental==0.50.0rc3",
-    #"qcelemental>=0.50.0rc3,<0.70.0",
+    "qcelemental>=0.50.0rc3,<0.70.0",
 ]
 
 [project.optional-dependencies]
 standard = [
     # needed for continuous hi-lvl interface: `mbres = ManyBodyComputer.from_manybodyinput(mbin)`
-    "qcengine>=0.50.0rc1,<0.70.0",  # TODO rc2
+    "qcengine>=0.50.0rc2,<0.70.0",
 ]
 tests = [
     "pytest",

--- a/qcmanybody/models/v1/manybody_output_pydv1.py
+++ b/qcmanybody/models/v1/manybody_output_pydv1.py
@@ -371,7 +371,28 @@ def _qcvars_translator(cls, reverse: bool = False) -> Dict[str, str]:
         return {v: k for k, v in qcvars_to_mbprop.items()}
 
 
+def _mbprop_convert_v(
+    self, target_version: int, /
+) -> Union["qcmanybody.models.v1.ManyBodyResultProperties", "qcmanybody.models.v2.ManyBodyProperties"]:
+    """Convert to instance of particular QCSchema version."""
+    from qcelemental.models.v1.basemodels import check_convertible_version
+
+    import qcmanybody as qcmb
+
+    if check_convertible_version(target_version, error="ManyBodyResultProperties") == "self":
+        return self
+
+    dself = self.model_dump()
+    if target_version == 2:
+        self_vN = qcmb.models.v2.ManyBodyProperties(**dself)
+    else:
+        assert False, target_version
+
+    return self_vN
+
+
 ManyBodyResultProperties.to_qcvariables = classmethod(_qcvars_translator)
+ManyBodyResultProperties.convert_v = _mbprop_convert_v
 
 
 # ====  Results  ================================================================
@@ -460,6 +481,7 @@ class ManyBodyResult(SuccessfulResultBase):
 
             dself["molecule"] = self.input_data.molecule.convert_v(target_version)
 
+            dself["properties"] = self.properties.convert_v(target_version)
             dself["cluster_properties"] = dself.pop("component_properties")
             dself["cluster_results"] = {
                 k: atres.convert_v(target_version) for k, atres in self.component_results.items()

--- a/qcmanybody/models/v2/many_body.py
+++ b/qcmanybody/models/v2/many_body.py
@@ -10,7 +10,15 @@ try:
 except ImportError:
     from pydantic import FieldValidationInfo as ValidationInfo
 
-from pydantic import Field, create_model, ConfigDict, field_validator, model_validator
+from pydantic import (
+    ConfigDict,
+    Field,
+    SerializerFunctionWrapHandler,
+    create_model,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 from qcelemental.models.v2 import (  # Array,
     AtomicProperties,
     AtomicResult,
@@ -639,17 +647,26 @@ class ProtoModelAllowExtra(ProtoModel):
 
 
 if TYPE_CHECKING:
-    ManyBodyProperties = ProtoModelAllowExtra
+    PreManyBodyProperties = ProtoModelAllowExtra
 else:
     # if/else suppresses a warning about using a dynamically generated class as Field type in ManyBodyResults
     # * deprecated but works: root_validator(skip_on_failure=True)(_validate_arb_max_nbody_fieldnames)
-    ManyBodyProperties = create_model(
+    PreManyBodyProperties = create_model(
         "ManyBodyProperties",
-        # __doc__=manybodyproperties_doc,  # needs later pydantic
+        __doc__=manybodyproperties_doc,
         __base__=ProtoModelAllowExtra,
         __validators__={"validator1": model_validator(mode="before")(_validate_arb_max_nbody_fieldnames)},
         **mbprop,
     )
+
+
+class ManyBodyProperties(PreManyBodyProperties):
+    @model_serializer(mode="wrap")
+    def _remove_none(self, handler: SerializerFunctionWrapHandler) -> Dict[str, Any]:
+        # Removes fields with a value of None from the serialized output.
+        # Leaves e.g., schema_name, which is different from v1 model.
+        serialized = handler(self)
+        return {k: v for k, v in serialized.items() if v is not None}
 
 
 def _qcvars_translator(cls, reverse: bool = False) -> Dict[str, str]:

--- a/qcmanybody/models/v2/many_body.py
+++ b/qcmanybody/models/v2/many_body.py
@@ -650,12 +650,12 @@ class ProtoModelAllowExtra(ProtoModel):
 
 
 if TYPE_CHECKING:
-    PreManyBodyProperties = ProtoModelAllowExtra
+    ManyBodyPropertiesBase = ProtoModelAllowExtra
 else:
     # if/else suppresses a warning about using a dynamically generated class as Field type in ManyBodyResults
     # * deprecated but works: root_validator(skip_on_failure=True)(_validate_arb_max_nbody_fieldnames)
-    PreManyBodyProperties = create_model(
-        "ManyBodyProperties",
+    ManyBodyPropertiesBase = create_model(
+        "ManyBodyPropertiesBase",
         __doc__=manybodyproperties_doc,
         __base__=ProtoModelAllowExtra,
         __validators__={"validator1": model_validator(mode="before")(_validate_arb_max_nbody_fieldnames)},
@@ -663,7 +663,7 @@ else:
     )
 
 
-class ManyBodyProperties(PreManyBodyProperties):
+class ManyBodyProperties(ManyBodyPropertiesBase):
     @model_serializer(mode="wrap")
     def _remove_none(self, handler: SerializerFunctionWrapHandler) -> Dict[str, Any]:
         # Removes fields with a value of None from the serialized output.

--- a/qcmanybody/models/v2/many_body.py
+++ b/qcmanybody/models/v2/many_body.py
@@ -95,6 +95,7 @@ class ManyBodyProtocols(ProtoModel):
 
         dself = self.model_dump()
         if target_version == 1:
+            dself.pop("schema_name")
             # serialization is compact, so use model to assure value
             dself.pop("cluster_results", None)
             dself["component_results"] = self.cluster_results.value
@@ -277,9 +278,11 @@ class ManyBodySpecification(ProtoModel):
             dself["keywords"].pop("schema_name")
             try:
                 dself["specification"].pop("schema_name")
+                dself["specification"]["specification"]["protocols"].pop("schema_name")
             except KeyError:
                 for spec in dself["specification"].values():
                     spec.pop("schema_name")
+                    spec["protocols"].pop("schema_name")
 
             dself.pop("program")  # not in v1
             dself["protocols"] = self.protocols.convert_v(target_version)
@@ -697,7 +700,28 @@ def _qcvars_translator(cls, reverse: bool = False) -> Dict[str, str]:
         return {v: k for k, v in qcvars_to_mbprop.items()}
 
 
+def _mbprop_convert_v(
+    self, target_version: int, /
+) -> Union["qcmanybody.models.v1.ManyBodyResultProperties", "qcmanybody.models.v2.ManyBodyProperties"]:
+    """Convert to instance of particular QCSchema version."""
+    import qcmanybody as qcmb
+
+    if check_convertible_version(target_version, error="ManyBodyProperties") == "self":
+        return self
+
+    dself = self.model_dump()
+    if target_version == 1:
+        dself.pop("schema_name", None)
+
+        self_vN = qcmb.models.v1.ManyBodyResultProperties(**dself)
+    else:
+        assert False, target_version
+
+    return self_vN
+
+
 ManyBodyProperties.to_qcvariables = classmethod(_qcvars_translator)
+ManyBodyProperties.convert_v = _mbprop_convert_v
 
 
 # ====  Results  ================================================================
@@ -780,7 +804,11 @@ class ManyBodyResult(SuccessfulResultBase):
             dself.pop("native_files")
             dself.pop("molecule")
 
-            dself["component_properties"] = dself.pop("cluster_properties")
+            dself["properties"] = self.properties.convert_v(target_version)
+            dself["component_properties"] = {
+                k: atprop.convert_v(target_version) for k, atprop in self.cluster_properties.items()
+            }
+            dself.pop("cluster_properties")
             dself["component_results"] = {
                 k: atres.convert_v(target_version) for k, atres in self.cluster_results.items()
             }

--- a/qcmanybody/models/v2/many_body.py
+++ b/qcmanybody/models/v2/many_body.py
@@ -10,19 +10,16 @@ try:
 except ImportError:
     from pydantic import FieldValidationInfo as ValidationInfo
 
-from pydantic import Field, create_model, field_validator, model_validator
+from pydantic import Field, create_model, ConfigDict, field_validator, model_validator
 from qcelemental.models.v2 import (  # Array,
     AtomicProperties,
-    AtomicProtocols,
     AtomicResult,
     AtomicSpecification,
     DriverEnum,
-    Model,
     Molecule,
-    ProtoModel,
     Provenance,
 )
-from qcelemental.models.v2.basemodels import ExtendedConfigDict, ProtoModel, check_convertible_version
+from qcelemental.models.v2.basemodels import ProtoModel, check_convertible_version
 from qcelemental.models.v2.types import Array  # return to above once qcel corrected
 
 from ...utils import provenance_stamp
@@ -78,8 +75,6 @@ class ManyBodyProtocols(ProtoModel):
     cluster_results: ClusterResultsProtocolEnum = Field(
         ClusterResultsProtocolEnum.none, description=str(ClusterResultsProtocolEnum.__doc__)
     )
-
-    model_config = ExtendedConfigDict(force_skip_defaults=True)
 
     def convert_v(
         self, target_version: int, /
@@ -639,21 +634,19 @@ def _validate_arb_max_nbody_fieldnames(cls, values):
     return values
 
 
-class ProtoModelSkipDefaults(ProtoModel):
-
-    # fields filtered in model_validator
-    model_config = ExtendedConfigDict(serialize_skip_defaults=True, force_skip_defaults=True, extra="allow")
+class ProtoModelAllowExtra(ProtoModel):
+    model_config = ConfigDict(extra="allow")
 
 
 if TYPE_CHECKING:
-    ManyBodyProperties = ProtoModelSkipDefaults
+    ManyBodyProperties = ProtoModelAllowExtra
 else:
     # if/else suppresses a warning about using a dynamically generated class as Field type in ManyBodyResults
     # * deprecated but works: root_validator(skip_on_failure=True)(_validate_arb_max_nbody_fieldnames)
     ManyBodyProperties = create_model(
         "ManyBodyProperties",
         # __doc__=manybodyproperties_doc,  # needs later pydantic
-        __base__=ProtoModelSkipDefaults,
+        __base__=ProtoModelAllowExtra,
         __validators__={"validator1": model_validator(mode="before")(_validate_arb_max_nbody_fieldnames)},
         **mbprop,
     )

--- a/qcmanybody/tests/test_schema_keywords.py
+++ b/qcmanybody/tests/test_schema_keywords.py
@@ -305,7 +305,7 @@ def test_mbe_sie(mbe_data, kws, ans, schema_versions):
         "calcinfo_nfrrrrrrrrrrr": 3,
     }, "Field names not allowed"),
 ])
-def test_mbproperties_expansion(kws, ans, schema_versions):
+def test_mbproperties_expansion(kws, ans, schema_versions, request):
     _qcmb, ManyBodyComputer, _qcel = schema_versions
 
     if isinstance(ans, str):
@@ -327,3 +327,10 @@ def test_mbproperties_expansion(kws, ans, schema_versions):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         assert len(input_model.dict(exclude_unset=True)) == ans
+
+    if "v2" in request.node.name:
+        assert len(input_model.model_dump()) == ans + 1, list(input_model.model_dump().keys())
+        assert sorted(input_model.model_dump().keys()) == sorted(list(kws.keys()) + ["schema_name"])
+    else:
+        assert len(input_model.model_dump()) == ans, list(input_model.model_dump().keys())
+        assert sorted(input_model.model_dump().keys()) == sorted(kws.keys())

--- a/qcmanybody/tests/test_schema_keywords.py
+++ b/qcmanybody/tests/test_schema_keywords.py
@@ -326,4 +326,4 @@ def test_mbproperties_expansion(kws, ans, schema_versions):
     # official leave this as dict(), not model_dump(), to ensure remains operational
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        assert len(input_model.dict()) == ans
+        assert len(input_model.dict(exclude_unset=True)) == ans


### PR DESCRIPTION
* `ManyBodyProperties.model_dump()` now includes `schema_name`, but not all the Nones
* won't pass as needs MolSSI/QCElemental#393