### PR TITLE
Fix arguments to warn function in generalized_optimization

### DIFF
--- a/qcmanybody/models/v1/generalized_optimization.py
+++ b/qcmanybody/models/v1/generalized_optimization.py
@@ -10,8 +10,8 @@ from .manybody_output_pydv1 import ManyBodyResult
 
 warn(
     f"GeneralizedOptimizationInput and GeneralizedOptimizationResult were experimental and are retired. Use OptimizationInput and OptimizationResult in v2 instead.",
+    category=FutureWarning,
     stacklevel=2,
-    FutureWarning,
 )
 
 # note that qcel QCInputSpecification and AtomicResult.schema_name needs editing


### PR DESCRIPTION
Fix the call to `warn()` in generalized_optimization.py (error is that positional argument `FutureWarning` follows keyword argument `stacklevel=2`)

Not exactly sure where it's getting imported, but it should work regardless.

Fixes issue #49